### PR TITLE
Fix: briefingData.events was object instead of array, crashing .filter()

### DIFF
--- a/client/src/contexts/co-pilot-context.tsx
+++ b/client/src/contexts/co-pilot-context.tsx
@@ -59,6 +59,7 @@ interface CoPilotContextValue {
     traffic: any;
     news: any;
     events: any;
+    marketEvents: any;
     schoolClosures: any;
     airport: any;
     isLoading: {
@@ -683,9 +684,11 @@ export function CoPilotProvider({ children }: { children: React.ReactNode }) {
       weather: weatherData?.weather || null,
       traffic: trafficData?.traffic || null,
       news: newsData?.news || null,
-      // 2026-03-28: Store full API response (events + marketEvents + market_name)
-      // Previously only stored eventsData?.events, dropping market events
-      events: eventsData || null,
+      // 2026-03-29: FIX - Unwrap events array from API response object
+      // Previously stored full response object, breaking .filter() calls downstream
+      // Now properly extracts events array AND marketEvents for separate access
+      events: eventsData?.events || null,
+      marketEvents: eventsData?.marketEvents || null,
       // 2026-01-10: Snake/camel tolerant - accept both server response formats
       schoolClosures: schoolClosuresData?.schoolClosures ?? schoolClosuresData?.school_closures ?? [],
       airport: airportData?.airportConditions ?? airportData?.airport_conditions ?? null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2419,6 +2419,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2458,6 +2459,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2478,6 +2480,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2498,6 +2501,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,6 +2522,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,6 +2543,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,6 +2564,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2578,6 +2585,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,6 +2606,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,6 +2627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2638,6 +2648,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2658,6 +2669,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2678,6 +2690,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2698,6 +2711,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2715,6 +2729,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2722,6 +2737,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
The 2026-03-28 change stored the full API response object as
briefingData.events instead of extracting the events array.
Downstream consumers (RideshareIntelTab) called .filter() on the
object, causing "_e.filter is not a function" crash.

Now properly unwraps events and marketEvents into separate fields.

https://claude.ai/code/session_01SE6dsdEtHkFFHvoLrcDwCZ