### PR TITLE
feat(events): public event sign-up POC with dynamic pricing + AI itinerary

### DIFF
--- a/client/src/pages/co-pilot/EventsAdminPage.tsx
+++ b/client/src/pages/co-pilot/EventsAdminPage.tsx
@@ -1,0 +1,391 @@
+// client/src/pages/co-pilot/EventsAdminPage.tsx
+// 2026-04-25: Admin view for hosted_events POC.
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+// Auth: requires logged-in user (mounted under ProtectedRoute).
+
+import { useEffect, useState, useCallback } from 'react';
+import { Loader2, Plus, Sparkles, ChevronRight, Trash2 } from 'lucide-react';
+import { getAuthHeader } from '@/contexts/auth-context';
+
+interface PriceTier {
+  min_count: number;
+  price_cents: number;
+}
+
+interface AdminEvent {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  event_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  location_name: string | null;
+  location_address: string | null;
+  max_attendees: number;
+  status: string;
+  price_tiers: PriceTier[];
+  itinerary_md: string | null;
+  itinerary_generated_at: string | null;
+  confirmed_count: string | number;
+  waitlist_count: string | number;
+  current_price_cents?: number | null;
+}
+
+interface Signup {
+  id: string;
+  full_name: string;
+  email: string;
+  phone: string | null;
+  pickup_address: string | null;
+  notes: string | null;
+  status: string;
+  price_cents_at_signup: number | null;
+  created_at: string;
+}
+
+function authFetch(url: string, init: RequestInit = {}) {
+  return fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+      ...(init.headers || {}),
+    },
+  });
+}
+
+function formatUSD(cents: number | null | undefined): string {
+  if (cents == null) return '—';
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export default function EventsAdminPage() {
+  const [events, setEvents] = useState<AdminEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await authFetch('/api/admin/events');
+      const data = await r.json();
+      if (data.ok) setEvents(data.events || []);
+      else setError(data.error || 'failed to load events');
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <header className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold">Hosted Events</h1>
+            <p className="text-sm text-slate-400 mt-1">Create and manage paid mentor sessions.</p>
+          </div>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="inline-flex items-center gap-2 rounded-lg bg-violet-600 hover:bg-violet-500 px-4 py-2 text-sm font-semibold"
+          >
+            <Plus className="w-4 h-4" /> New event
+          </button>
+        </header>
+
+        {showCreate && (
+          <CreateEventForm
+            onCancel={() => setShowCreate(false)}
+            onCreated={() => { setShowCreate(false); refresh(); }}
+          />
+        )}
+
+        {loading && (
+          <div className="flex items-center gap-2 text-slate-400"><Loader2 className="w-4 h-4 animate-spin" /> Loading…</div>
+        )}
+        {error && <div className="rounded-md bg-red-900/40 border border-red-700 p-3 text-red-200 text-sm">{error}</div>}
+
+        <div className="grid gap-2">
+          {events.map(ev => (
+            <button
+              key={ev.id}
+              onClick={() => setSelectedId(ev.id === selectedId ? null : ev.id)}
+              className="text-left rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-700 p-4"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <div className="font-semibold">{ev.title}</div>
+                  <div className="text-xs text-slate-400 mt-0.5">
+                    {ev.event_date} · {ev.status} · {ev.confirmed_count}/{ev.max_attendees} confirmed · {ev.waitlist_count} waitlist
+                  </div>
+                </div>
+                <ChevronRight className={`w-4 h-4 text-slate-500 transition ${ev.id === selectedId ? 'rotate-90' : ''}`} />
+              </div>
+              {selectedId === ev.id && (
+                <div onClick={e => e.stopPropagation()} className="mt-4 pt-4 border-t border-slate-800">
+                  <EventDetail eventId={ev.id} onChange={refresh} />
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CreateEventForm({ onCancel, onCreated }: { onCancel: () => void; onCreated: () => void }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    slug: '',
+    title: '',
+    description: '',
+    event_date: '',
+    start_time: '',
+    end_time: '',
+    location_name: '',
+    location_address: '',
+    max_attendees: 6,
+    price_tiers: '[{"min_count":1,"price_cents":15000},{"min_count":3,"price_cents":10000},{"min_count":5,"price_cents":7500}]',
+    status: 'draft',
+  });
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setErr(null);
+    try {
+      let priceTiers: PriceTier[];
+      try { priceTiers = JSON.parse(form.price_tiers); }
+      catch { throw new Error('price_tiers must be valid JSON'); }
+
+      const r = await authFetch('/api/admin/events', {
+        method: 'POST',
+        body: JSON.stringify({ ...form, price_tiers: priceTiers }),
+      });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'create failed');
+      onCreated();
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function set<K extends keyof typeof form>(k: K, v: typeof form[K]) {
+    setForm(prev => ({ ...prev, [k]: v }));
+  }
+
+  return (
+    <form onSubmit={submit} className="rounded-lg bg-slate-900 border border-slate-800 p-5 mb-6 space-y-3">
+      <h2 className="text-lg font-semibold">New event</h2>
+      <div className="grid sm:grid-cols-2 gap-3">
+        <Input label="Slug *" value={form.slug} onChange={v => set('slug', v)} placeholder="dallas-honey-holes-may3" required />
+        <Input label="Title *" value={form.title} onChange={v => set('title', v)} required />
+        <Input label="Date *" type="date" value={form.event_date} onChange={v => set('event_date', v)} required />
+        <Input label="Max attendees" type="number" value={String(form.max_attendees)} onChange={v => set('max_attendees', parseInt(v) || 6)} />
+        <Input label="Start time" type="time" value={form.start_time} onChange={v => set('start_time', v)} />
+        <Input label="End time" type="time" value={form.end_time} onChange={v => set('end_time', v)} />
+        <Input label="Location name" value={form.location_name} onChange={v => set('location_name', v)} />
+        <Input label="Location address" value={form.location_address} onChange={v => set('location_address', v)} />
+      </div>
+      <Textarea label="Description" value={form.description} onChange={v => set('description', v)} rows={3} />
+      <Textarea label="Price tiers (JSON)" value={form.price_tiers} onChange={v => set('price_tiers', v)} rows={3} />
+      <label className="block text-sm">
+        <div className="text-slate-300 mb-1">Status</div>
+        <select className="adminInput" value={form.status} onChange={e => set('status', e.target.value)}>
+          <option value="draft">draft</option>
+          <option value="published">published</option>
+          <option value="closed">closed</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </label>
+      {err && <div className="rounded bg-red-900/40 border border-red-700 p-2 text-sm text-red-200">{err}</div>}
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onCancel} className="px-4 py-2 rounded text-slate-300 hover:bg-slate-800">Cancel</button>
+        <button disabled={submitting} className="px-4 py-2 rounded bg-violet-600 hover:bg-violet-500 disabled:opacity-60 inline-flex items-center gap-2">
+          {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+          Create
+        </button>
+      </div>
+      <style>{`
+        .adminInput { width:100%; background:rgb(15 23 42); border:1px solid rgb(51 65 85); border-radius:0.5rem; padding:0.5rem 0.75rem; color:rgb(241 245 249); font-size:0.875rem; }
+        .adminInput:focus { outline:none; border-color:rgb(139 92 246); }
+      `}</style>
+    </form>
+  );
+}
+
+function EventDetail({ eventId, onChange }: { eventId: string; onChange: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [event, setEvent] = useState<AdminEvent | null>(null);
+  const [signups, setSignups] = useState<Signup[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await authFetch(`/api/admin/events/${eventId}`);
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'load failed');
+      setEvent(data.event);
+      setSignups(data.signups || []);
+    } catch (e: any) { setErr(e.message); }
+    finally { setLoading(false); }
+  }, [eventId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function generate() {
+    setBusy('itinerary');
+    setErr(null);
+    try {
+      const r = await authFetch(`/api/admin/events/${eventId}/generate-itinerary`, { method: 'POST' });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'failed');
+      await load();
+    } catch (e: any) { setErr(e.message); }
+    finally { setBusy(null); }
+  }
+
+  async function promote() {
+    setBusy('promote');
+    setErr(null);
+    try {
+      const r = await authFetch(`/api/admin/events/${eventId}/promote-waitlist`, { method: 'POST' });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'failed');
+      await load();
+      onChange();
+    } catch (e: any) { setErr(e.message); }
+    finally { setBusy(null); }
+  }
+
+  async function deleteEvent() {
+    if (!confirm('Delete this event? All signups will be removed.')) return;
+    setBusy('delete');
+    try {
+      const r = await authFetch(`/api/admin/events/${eventId}`, { method: 'DELETE' });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'failed');
+      onChange();
+    } catch (e: any) { setErr(e.message); }
+    finally { setBusy(null); }
+  }
+
+  if (loading) return <div className="text-slate-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Loading…</div>;
+  if (!event) return <div className="text-red-300 text-sm">{err || 'not found'}</div>;
+
+  const confirmed = signups.filter(s => s.status === 'confirmed');
+  const waitlist = signups.filter(s => s.status === 'waitlist');
+
+  return (
+    <div className="space-y-4 text-sm">
+      <div className="flex flex-wrap gap-2">
+        <button onClick={generate} disabled={busy !== null || confirmed.length === 0}
+          className="inline-flex items-center gap-2 rounded bg-fuchsia-700 hover:bg-fuchsia-600 disabled:opacity-50 px-3 py-1.5 text-xs font-semibold">
+          {busy === 'itinerary' ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
+          Generate itinerary
+        </button>
+        <button onClick={promote} disabled={busy !== null || waitlist.length === 0}
+          className="rounded bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 px-3 py-1.5 text-xs font-semibold">
+          Promote next from waitlist
+        </button>
+        <button onClick={deleteEvent} disabled={busy !== null}
+          className="ml-auto inline-flex items-center gap-1 rounded bg-red-900 hover:bg-red-800 px-3 py-1.5 text-xs font-semibold">
+          <Trash2 className="w-3 h-3" /> Delete
+        </button>
+      </div>
+
+      <div className="text-xs text-slate-400">
+        Public URL: <code className="text-slate-300">/events/{event.slug}</code> · current price {formatUSD(event.current_price_cents)}
+      </div>
+
+      {err && <div className="rounded bg-red-900/40 border border-red-700 p-2 text-red-200">{err}</div>}
+
+      <RosterTable title={`Confirmed (${confirmed.length}/${event.max_attendees})`} signups={confirmed} />
+      {waitlist.length > 0 && <RosterTable title={`Waitlist (${waitlist.length})`} signups={waitlist} />}
+
+      {event.itinerary_md && (
+        <div className="rounded bg-slate-950 border border-slate-800 p-4">
+          <div className="text-xs text-slate-400 mb-2">
+            Itinerary {event.itinerary_generated_at && `· ${new Date(event.itinerary_generated_at).toLocaleString()}`}
+          </div>
+          <pre className="whitespace-pre-wrap text-slate-200 text-xs">{event.itinerary_md}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RosterTable({ title, signups }: { title: string; signups: Signup[] }) {
+  if (signups.length === 0) return null;
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-slate-400 mb-1">{title}</div>
+      <div className="rounded border border-slate-800 overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-slate-900">
+            <tr>
+              <th className="text-left px-2 py-1">Name</th>
+              <th className="text-left px-2 py-1">Email</th>
+              <th className="text-left px-2 py-1">Phone</th>
+              <th className="text-left px-2 py-1">Pickup</th>
+              <th className="text-right px-2 py-1">Price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {signups.map(s => (
+              <tr key={s.id} className="border-t border-slate-800">
+                <td className="px-2 py-1">{s.full_name}</td>
+                <td className="px-2 py-1"><a href={`mailto:${s.email}`} className="text-violet-400 hover:underline">{s.email}</a></td>
+                <td className="px-2 py-1">{s.phone || '—'}</td>
+                <td className="px-2 py-1 truncate max-w-xs">{s.pickup_address || '—'}</td>
+                <td className="px-2 py-1 text-right">{formatUSD(s.price_cents_at_signup)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Input({ label, value, onChange, type = 'text', required, placeholder }: {
+  label: string; value: string; onChange: (v: string) => void;
+  type?: string; required?: boolean; placeholder?: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <div className="text-slate-300 mb-1">{label}</div>
+      <input
+        type={type} value={value} required={required} placeholder={placeholder}
+        onChange={e => onChange(e.target.value)}
+        className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-1.5 text-slate-100 focus:outline-none focus:border-violet-500"
+      />
+    </label>
+  );
+}
+
+function Textarea({ label, value, onChange, rows }: {
+  label: string; value: string; onChange: (v: string) => void; rows?: number;
+}) {
+  return (
+    <label className="block text-sm">
+      <div className="text-slate-300 mb-1">{label}</div>
+      <textarea
+        value={value} rows={rows} onChange={e => onChange(e.target.value)}
+        className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-1.5 text-slate-100 focus:outline-none focus:border-violet-500 font-mono text-xs"
+      />
+    </label>
+  );
+}

--- a/client/src/pages/events/PublicEventSignupPage.tsx
+++ b/client/src/pages/events/PublicEventSignupPage.tsx
@@ -1,0 +1,318 @@
+// client/src/pages/events/PublicEventSignupPage.tsx
+// 2026-04-25: Public event detail + signup form (no auth required).
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, Calendar, MapPin, Users, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+
+interface PriceTier {
+  min_count: number;
+  price_cents: number;
+}
+
+interface PublicEvent {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  event_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  location_name: string | null;
+  location_address: string | null;
+  max_attendees: number;
+  confirmed_count: number;
+  waitlist_count: number;
+  seats_left: number;
+  is_full: boolean;
+  current_price_cents: number | null;
+  price_tiers: PriceTier[];
+}
+
+function formatUSD(cents: number | null): string {
+  if (cents == null) return '—';
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(d: string): string {
+  try {
+    return new Date(d + 'T00:00:00').toLocaleDateString('en-US', {
+      weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+    });
+  } catch {
+    return d;
+  }
+}
+
+export default function PublicEventSignupPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [event, setEvent] = useState<PublicEvent | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [pickupAddress, setPickupAddress] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{ status: string; message: string; price_cents: number | null } | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    fetch(`/api/public/events/${slug}`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) setEvent(data.event);
+        else setError(data.error || 'event not found');
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!slug || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/public/events/${slug}/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          full_name: fullName,
+          email,
+          phone: phone || undefined,
+          pickup_address: pickupAddress || undefined,
+          notes: notes || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setResult({ status: data.status, message: data.message, price_cents: data.price_cents });
+      } else {
+        setError(data.error || 'signup failed');
+      }
+    } catch (e: any) {
+      setError(e.message || 'signup failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center">
+        <Loader2 className="w-6 h-6 animate-spin text-violet-400" />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-100 px-4 py-12">
+        <div className="max-w-xl mx-auto">
+          <Link to="/events" className="inline-flex items-center gap-1 text-slate-400 hover:text-slate-200 text-sm mb-6">
+            <ArrowLeft className="w-4 h-4" /> Back to events
+          </Link>
+          <div className="rounded-md bg-red-900/40 border border-red-700 p-4 text-red-200">
+            {error || 'Event not found.'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="max-w-2xl mx-auto px-4 py-10">
+        <Link to="/events" className="inline-flex items-center gap-1 text-slate-400 hover:text-slate-200 text-sm mb-6">
+          <ArrowLeft className="w-4 h-4" /> Back to events
+        </Link>
+
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">{event.title}</h1>
+          {event.description && <p className="mt-3 text-slate-300">{event.description}</p>}
+
+          <div className="mt-5 grid sm:grid-cols-2 gap-3 text-sm text-slate-300">
+            <div className="flex items-start gap-2">
+              <Calendar className="w-4 h-4 mt-0.5 text-violet-400 shrink-0" />
+              <span>
+                {formatDate(event.event_date)}
+                {event.start_time ? ` · ${event.start_time}` : ''}
+                {event.end_time ? ` – ${event.end_time}` : ''}
+              </span>
+            </div>
+            {event.location_name && (
+              <div className="flex items-start gap-2">
+                <MapPin className="w-4 h-4 mt-0.5 text-violet-400 shrink-0" />
+                <div>
+                  <div>{event.location_name}</div>
+                  {event.location_address && (
+                    <div className="text-slate-400 text-xs">{event.location_address}</div>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="flex items-start gap-2">
+              <Users className="w-4 h-4 mt-0.5 text-violet-400 shrink-0" />
+              <span>
+                {event.is_full
+                  ? <span className="text-amber-400">All 6 seats taken — joining the waitlist</span>
+                  : `${event.seats_left} of ${event.max_attendees} seats left`}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="mb-6 rounded-lg bg-violet-950/40 border border-violet-800 p-5">
+          <div className="flex items-baseline justify-between">
+            <div>
+              <div className="text-sm text-violet-300 uppercase tracking-wide">Current price per person</div>
+              <div className="text-3xl font-bold text-violet-100">{formatUSD(event.current_price_cents)}</div>
+            </div>
+            <div className="text-xs text-violet-300/80">{event.confirmed_count} confirmed</div>
+          </div>
+
+          {event.price_tiers && event.price_tiers.length > 1 && (
+            <div className="mt-3 pt-3 border-t border-violet-900 text-xs text-violet-300/90">
+              <div className="font-medium mb-1">Price drops as more people sign up:</div>
+              <ul className="space-y-0.5">
+                {event.price_tiers.map((t, i) => (
+                  <li key={i}>
+                    {t.min_count}+ signed up → <span className="font-mono">{formatUSD(t.price_cents)}</span>
+                    {' '}per person
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {result ? (
+          <div className={`rounded-lg p-6 border ${
+            result.status === 'confirmed'
+              ? 'bg-emerald-950/40 border-emerald-700'
+              : 'bg-amber-950/40 border-amber-700'
+          }`}>
+            <div className="flex items-start gap-3">
+              {result.status === 'confirmed'
+                ? <CheckCircle2 className="w-6 h-6 text-emerald-400 shrink-0" />
+                : <AlertCircle className="w-6 h-6 text-amber-400 shrink-0" />}
+              <div>
+                <div className="text-lg font-semibold">
+                  {result.status === 'confirmed' ? "You're confirmed!" : "You're on the waitlist"}
+                </div>
+                <p className="mt-1 text-sm text-slate-300">{result.message}</p>
+                {result.price_cents != null && result.status === 'confirmed' && (
+                  <p className="mt-3 text-sm">
+                    Your locked-in price: <strong className="text-emerald-300">{formatUSD(result.price_cents)}</strong>
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <h2 className="text-lg font-semibold">Reserve your seat</h2>
+
+            <Field label="Full name *">
+              <input
+                type="text"
+                required
+                value={fullName}
+                onChange={e => setFullName(e.target.value)}
+                className="input"
+              />
+            </Field>
+
+            <Field label="Email *">
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="input"
+              />
+            </Field>
+
+            <Field label="Phone">
+              <input
+                type="tel"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+                className="input"
+              />
+            </Field>
+
+            <Field label="Pickup address (helps us route the day)">
+              <input
+                type="text"
+                value={pickupAddress}
+                onChange={e => setPickupAddress(e.target.value)}
+                placeholder="e.g. 123 Main St, Dallas TX"
+                className="input"
+              />
+            </Field>
+
+            <Field label="Anything else we should know?">
+              <textarea
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                rows={3}
+                className="input"
+              />
+            </Field>
+
+            {error && (
+              <div className="rounded-md bg-red-900/40 border border-red-700 p-3 text-sm text-red-200">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:opacity-60 disabled:cursor-not-allowed py-3 font-semibold transition"
+            >
+              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+              {event.is_full ? 'Join waitlist' : 'Reserve my seat'}
+            </button>
+
+            <p className="text-xs text-slate-500 text-center">
+              No payment is collected here — Melody will follow up by email with payment details.
+            </p>
+          </form>
+        )}
+      </div>
+
+      <style>{`
+        .input {
+          width: 100%;
+          background: rgb(15 23 42);
+          border: 1px solid rgb(51 65 85);
+          border-radius: 0.5rem;
+          padding: 0.625rem 0.875rem;
+          color: rgb(241 245 249);
+          font-size: 0.875rem;
+        }
+        .input:focus {
+          outline: none;
+          border-color: rgb(139 92 246);
+          box-shadow: 0 0 0 3px rgb(139 92 246 / 0.2);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <div className="text-sm text-slate-300 mb-1">{label}</div>
+      {children}
+    </label>
+  );
+}

--- a/client/src/pages/events/PublicEventsListPage.tsx
+++ b/client/src/pages/events/PublicEventsListPage.tsx
@@ -1,0 +1,131 @@
+// client/src/pages/events/PublicEventsListPage.tsx
+// 2026-04-25: Public list of upcoming Melody-hosted events (no auth required).
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Calendar, MapPin, Users, Loader2 } from 'lucide-react';
+
+interface PublicEvent {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  event_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  location_name: string | null;
+  location_address: string | null;
+  max_attendees: number;
+  confirmed_count: number;
+  waitlist_count: number;
+  seats_left: number;
+  is_full: boolean;
+  current_price_cents: number | null;
+}
+
+function formatUSD(cents: number | null): string {
+  if (cents == null) return '—';
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(d: string): string {
+  try {
+    return new Date(d + 'T00:00:00').toLocaleDateString('en-US', {
+      weekday: 'short', month: 'short', day: 'numeric', year: 'numeric',
+    });
+  } catch {
+    return d;
+  }
+}
+
+export default function PublicEventsListPage() {
+  const [events, setEvents] = useState<PublicEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/public/events')
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) setEvents(data.events || []);
+        else setError(data.error || 'failed to load events');
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="max-w-4xl mx-auto px-4 py-12">
+        <header className="mb-10">
+          <h1 className="text-4xl font-bold tracking-tight">Vecto Pilot Events</h1>
+          <p className="mt-2 text-slate-400">
+            Upcoming driver mentor sessions hosted by Melody. Reserve your spot — only 6 seats per event.
+          </p>
+        </header>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading events...
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md bg-red-900/40 border border-red-700 p-4 text-red-200">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && events.length === 0 && (
+          <div className="rounded-md bg-slate-900 border border-slate-800 p-6 text-slate-400">
+            No upcoming events right now. Check back soon.
+          </div>
+        )}
+
+        <div className="grid gap-4">
+          {events.map(ev => (
+            <Link
+              key={ev.id}
+              to={`/events/${ev.slug}`}
+              className="block rounded-lg bg-slate-900 border border-slate-800 hover:border-violet-500/60 transition p-6"
+            >
+              <div className="flex justify-between items-start gap-4 mb-2">
+                <h2 className="text-2xl font-semibold">{ev.title}</h2>
+                <div className="text-right shrink-0">
+                  <div className="text-2xl font-bold text-violet-400">{formatUSD(ev.current_price_cents)}</div>
+                  <div className="text-xs text-slate-500">per person</div>
+                </div>
+              </div>
+
+              {ev.description && (
+                <p className="text-slate-400 text-sm mb-4 line-clamp-2">{ev.description}</p>
+              )}
+
+              <div className="grid sm:grid-cols-3 gap-3 text-sm text-slate-300">
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-violet-400" />
+                  <span>{formatDate(ev.event_date)}{ev.start_time ? ` · ${ev.start_time}` : ''}</span>
+                </div>
+                {ev.location_name && (
+                  <div className="flex items-center gap-2">
+                    <MapPin className="w-4 h-4 text-violet-400" />
+                    <span className="truncate">{ev.location_name}</span>
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
+                  <Users className="w-4 h-4 text-violet-400" />
+                  <span>
+                    {ev.is_full
+                      ? <span className="text-amber-400">Full · waitlist open</span>
+                      : `${ev.seats_left} of ${ev.max_attendees} seats left`}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -31,6 +31,10 @@ import AuthRedirect from '@/components/auth/AuthRedirect';
 import ConciergePage from '@/pages/co-pilot/ConciergePage';
 import PublicConciergePage from '@/pages/concierge/PublicConciergePage';
 import LandingPage from '@/pages/landing/LandingPage';
+// 2026-04-25: Hosted-event signup POC — see docs/plans/PLAN_event-signup-page-2026-04-25.md
+import PublicEventsListPage from '@/pages/events/PublicEventsListPage';
+import PublicEventSignupPage from '@/pages/events/PublicEventSignupPage';
+import EventsAdminPage from '@/pages/co-pilot/EventsAdminPage';
 
 export const router = createBrowserRouter([
   // ═══════════════════════════════════════════════════════════════════════════
@@ -78,6 +82,16 @@ export const router = createBrowserRouter([
   {
     path: '/demo',
     element: <LandingPage />,
+  },
+
+  // 2026-04-25: Public event sign-up (POC) — hosted_events table
+  {
+    path: '/events',
+    element: <PublicEventsListPage />,
+  },
+  {
+    path: '/events/:slug',
+    element: <PublicEventSignupPage />,
   },
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -173,6 +187,11 @@ export const router = createBrowserRouter([
       {
         path: 'help',
         element: <HelpPage />,
+      },
+      // 2026-04-25: Hosted-event admin (POC) — manage paid mentor sessions
+      {
+        path: 'events-admin',
+        element: <EventsAdminPage />,
       },
     ],
   },

--- a/docs/plans/PLAN_event-signup-page-2026-04-25.md
+++ b/docs/plans/PLAN_event-signup-page-2026-04-25.md
@@ -1,0 +1,186 @@
+# PLAN: Public Event Sign-Up Page (POC)
+
+**Author:** Claude Opus 4.7 (1M context)
+**Date:** 2026-04-25
+**Branch:** `claude/add-event-signup-page-mapyz`
+**Status:** Pre-approved by Melody as POC ("ship asap, public, fastest model")
+
+---
+
+## 1. Objectives
+
+Ship a public-facing event sign-up flow on Vecto Pilot so Melody can run paid driver-mentor sessions (the kind she's been promoting on Next Door):
+
+- Public page lists upcoming events
+- Each event capped at **6 attendees**, with **waitlist** beyond cap
+- **Dynamic price per attendee** — cost-sharing curve (more signups → lower per-person price), config-driven per event
+- **Email alert to Melody** on every signup (uses existing Resend infra)
+- **Admin-triggered AI itinerary** — once roster locks, Melody clicks a button and the system generates a pickup/route/timing itinerary from attendee addresses + event location
+
+## 2. Non-goals (deferred to v2)
+
+- **Payment collection.** v1 displays price only — Melody collects payment off-platform (Cash App / Zelle / etc.) per Next Door norms. Stripe Checkout integration is out of scope.
+- **Auto-promotion of waitlist on cancellation.** v1 = manual promote button.
+- **Recurring events / templates.** v1 = each event is a standalone row.
+- **Per-attendee individual itineraries.** v1 = one shared itinerary per event for the whole roster.
+- **SMS notifications.** v1 = email only.
+
+## 3. POC defaults (locked in without follow-up Q&A)
+
+| Question | Default chosen | Rationale |
+|---|---|---|
+| Audience | Drivers attending Melody-hosted paid sessions | Matches Next Door context + max-6 + addresses |
+| Events source | New `hosted_events` table (NOT `discovered_events`) | Rule 11 forbids polluting briefing pipeline with curated events |
+| Pricing curve shape | Tiered cost-sharing JSONB on each event | Arbitrary curves without re-migrating |
+| Pricing direction | Descending per-person (more signups → lower per-person price) | Matches "cost split" mental model from Next Door post |
+| Alert channel | Email to `melodydashora@gmail.com` via existing Resend | Infra already wired in `server/lib/notifications/email-alerts.js` |
+| Itinerary trigger | Admin-only, manual button | Avoids wasting AI calls on cancellable signups |
+| Itinerary model | `claude-haiku-4-5` ("fastest model" per ask) | Simple summarization-class task, sub-second responses |
+| Waitlist promotion | Manual button in admin | Simpler than auto-promote; no email-on-promote in v1 |
+| Payments | RSVP only, display price | Defer Stripe to v2 |
+| Auth on signup form | None (public) | POC; rely on email uniqueness + admin moderation |
+| Auth on admin views | `requireAuth` middleware (any logged-in user) | Acceptable for single-operator POC; tighten to role check in v2 |
+
+## 4. Data model
+
+```sql
+-- New table — Melody-curated paid events. Distinct from discovered_events (system-discovered).
+CREATE TABLE hosted_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug          text NOT NULL UNIQUE,        -- URL-safe, e.g. "dallas-honey-holes-walk-may3"
+  title         text NOT NULL,
+  description   text,
+  event_date    date NOT NULL,
+  start_time    time,                        -- local time (event timezone implicit = America/Chicago for now)
+  end_time      time,
+  location_name text,
+  location_address text,
+  max_attendees int  NOT NULL DEFAULT 6,
+  price_tiers   jsonb NOT NULL DEFAULT '[{"min_count":1,"price_cents":12000}]',
+  status        text NOT NULL DEFAULT 'draft',   -- draft | published | closed | cancelled
+  itinerary_md  text,                            -- last-generated itinerary markdown
+  itinerary_generated_at timestamptz,
+  created_by    uuid REFERENCES users(user_id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_hosted_events_published_date
+  ON hosted_events (status, event_date) WHERE status = 'published';
+
+CREATE TABLE event_signups (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id      uuid NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+  full_name     text NOT NULL,
+  email         text NOT NULL,
+  phone         text,
+  pickup_address text,
+  notes         text,
+  status        text NOT NULL DEFAULT 'confirmed',  -- confirmed | waitlist | cancelled
+  price_cents_at_signup int,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (event_id, email)
+);
+
+CREATE INDEX idx_event_signups_event_status_created
+  ON event_signups (event_id, status, created_at);
+```
+
+## 5. Files
+
+### Created
+| Path | Purpose |
+|---|---|
+| `migrations/20260425_event_signup_poc.sql` | Schema |
+| `server/lib/events/pricing.js` | Pure `computePrice(tiers, count)` |
+| `server/lib/events/itinerary.js` | `generateItinerary(event, signups)` via Anthropic Haiku |
+| `server/api/events/public-events.js` | `GET /api/public/events`, `GET /api/public/events/:slug`, `POST /api/public/events/:slug/signup` |
+| `server/api/events/admin-events.js` | Admin CRUD + signups list + generate-itinerary + promote-waitlist |
+| `client/src/pages/events/PublicEventsListPage.tsx` | Public list |
+| `client/src/pages/events/PublicEventSignupPage.tsx` | Public detail + signup form |
+| `client/src/pages/co-pilot/EventsAdminPage.tsx` | Admin view |
+
+### Modified
+| Path | Change |
+|---|---|
+| `server/lib/notifications/email-alerts.js` | Add `sendEventSignupAlert({event, signup, total, status})` |
+| `server/bootstrap/routes.js` | Mount `/api/public/events` and `/api/admin/events` |
+| `client/src/routes.tsx` | Add `/events` (public list), `/events/:slug` (public detail), `/co-pilot/events-admin` (protected) |
+
+## 6. Pricing logic
+
+```js
+// server/lib/events/pricing.js
+// tiers: [{min_count, price_cents}, ...] sorted ascending by min_count
+// returns the price_cents whose min_count is the largest <= confirmedCount.
+// confirmedCount = number of currently confirmed signups (NOT including waitlist).
+export function computePrice(tiers, confirmedCount) {
+  if (!Array.isArray(tiers) || tiers.length === 0) return null;
+  const sorted = [...tiers].sort((a, b) => a.min_count - b.min_count);
+  let chosen = sorted[0].price_cents;
+  for (const t of sorted) {
+    if (confirmedCount >= t.min_count) chosen = t.price_cents;
+    else break;
+  }
+  return chosen;
+}
+```
+
+Example for "Dallas Honey-Holes Walk":
+```json
+[
+  {"min_count": 1, "price_cents": 15000},
+  {"min_count": 3, "price_cents": 10000},
+  {"min_count": 5, "price_cents": 7500}
+]
+```
+- 1–2 signed up → $150/person displayed
+- 3–4 signed up → $100/person displayed
+- 5–6 signed up → $75/person displayed
+
+**Important:** `price_cents_at_signup` is captured on the `event_signups` row at signup time so attendees know what they committed to even if the displayed price moves.
+
+## 7. Itinerary generation
+
+`POST /api/admin/events/:id/generate-itinerary` calls `claude-haiku-4-5` with:
+- System: "You are a logistics coordinator for a paid rideshare driver mentorship session. Generate a concise pickup-and-route plan."
+- User: structured JSON containing event metadata + array of confirmed signups (name, pickup_address)
+- Output: markdown saved to `hosted_events.itinerary_md` and shown in admin view, copy/pasteable for sharing.
+
+No background jobs (Rule 11 compliance — even though Rule 11 is about discovered events, the spirit is "no autonomous AI work for events").
+
+## 8. Notification flow
+
+On `POST /api/public/events/:slug/signup`:
+1. Insert into `event_signups` with status auto-determined (confirmed if `count(confirmed) < max_attendees`, else waitlist).
+2. Capture `price_cents_at_signup`.
+3. Fire-and-forget `sendEventSignupAlert(...)` — Resend email to `melodydashora@gmail.com` with attendee details + current roster snapshot.
+4. Return `{ ok: true, status, price_cents }` to client.
+
+## 9. Test cases (Melody to verify)
+
+| # | Test | Expected |
+|---|---|---|
+| T1 | Run migration on dev DB | `\d hosted_events` and `\d event_signups` show schema; no errors |
+| T2 | `GET /api/public/events` returns empty list initially | `{ events: [] }` |
+| T3 | Admin creates event with 6 max + 3-tier pricing | Event appears in `GET /api/public/events` once status='published' |
+| T4 | Sign up 6 attendees | All `confirmed`; price_cents_at_signup matches tier; 6 emails arrive |
+| T5 | Sign up 7th attendee | Status `waitlist`; email arrives flagged WAITLIST |
+| T6 | Duplicate email for same event | 409 with friendly error; no email sent |
+| T7 | Click "Generate Itinerary" with 4 signups | Markdown returned + persisted; visible in admin |
+| T8 | Click "Promote next from waitlist" | First waitlist row → confirmed; price recomputed for new count |
+| T9 | TypeScript build (`npm run build` or vite build) | Clean |
+| T10 | Visit `/events` and `/events/<slug>` while signed out | Pages render publicly |
+| T11 | Visit `/co-pilot/events-admin` while signed out | Redirected to sign-in |
+
+## 10. Risks / known limitations
+
+- **No payment integration** — attendees may flake without skin in the game. Acceptable for POC; Melody can ask for a Cash App ping in the post-signup confirmation message.
+- **Email-only contact** — no SMS reminder loop. Add in v2 if attendance becomes an issue.
+- **Single-timezone assumption** — start_time is local America/Chicago; cross-market expansion needs a timezone column.
+- **Itinerary quality depends on address quality** — Haiku will hallucinate distances; Google Distance Matrix integration deferred to v2.
+- **Rule 8 surface check:** `hosted_events` is intentionally NOT in the Coach's write-access table per Rule 8 — these are operator-curated, not Coach-discovered.
+
+## 11. Test approval
+
+Per Rule 1, code lands behind this plan; **Melody must run T1–T11 and reply "all tests passed"** before this graduates from POC.

--- a/docs/plans/PLAN_event-signup-page-2026-04-25.md
+++ b/docs/plans/PLAN_event-signup-page-2026-04-25.md
@@ -19,7 +19,7 @@ Ship a public-facing event sign-up flow on Vecto Pilot so Melody can run paid dr
 
 ## 2. Non-goals (deferred to v2)
 
-- **Payment collection.** v1 displays price only — Melody collects payment off-platform (Cash App / Zelle / etc.) per Next Door norms. Stripe Checkout integration is out of scope.
+- **Payment collection.** v1 displays price only — Melody collects payment off-platform (Cash App / Zelle / etc.) per Next Door norms. v2 will integrate **Square** (not Stripe) — likely Square Invoices API, sending a per-attendee invoice link from inside the existing `sendEventSignupAlert` fire-and-forget block. No schema change required (`price_cents_at_signup` is already captured at signup time).
 - **Auto-promotion of waitlist on cancellation.** v1 = manual promote button.
 - **Recurring events / templates.** v1 = each event is a standalone row.
 - **Per-attendee individual itineraries.** v1 = one shared itinerary per event for the whole roster.
@@ -37,7 +37,7 @@ Ship a public-facing event sign-up flow on Vecto Pilot so Melody can run paid dr
 | Itinerary trigger | Admin-only, manual button | Avoids wasting AI calls on cancellable signups |
 | Itinerary model | `claude-haiku-4-5` ("fastest model" per ask) | Simple summarization-class task, sub-second responses |
 | Waitlist promotion | Manual button in admin | Simpler than auto-promote; no email-on-promote in v1 |
-| Payments | RSVP only, display price | Defer Stripe to v2 |
+| Payments | RSVP only, display price | Defer Square integration to v2 |
 | Auth on signup form | None (public) | POC; rely on email uniqueness + admin moderation |
 | Auth on admin views | `requireAuth` middleware (any logged-in user) | Acceptable for single-operator POC; tighten to role check in v2 |
 

--- a/migrations/20260425_event_signup_poc.sql
+++ b/migrations/20260425_event_signup_poc.sql
@@ -1,0 +1,54 @@
+-- 2026-04-25: POC public event sign-up flow
+-- See docs/plans/PLAN_event-signup-page-2026-04-25.md
+-- Two new tables: hosted_events (Melody-curated paid sessions) and event_signups (attendee roster).
+-- Distinct from discovered_events (system-discovered via PredictHQ/Ticketmaster) per Rule 11.
+-- Idempotent.
+
+CREATE TABLE IF NOT EXISTS "hosted_events" (
+  "id"               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "slug"             text NOT NULL UNIQUE,
+  "title"            text NOT NULL,
+  "description"      text,
+  "event_date"       date NOT NULL,
+  "start_time"       time,
+  "end_time"         time,
+  "location_name"    text,
+  "location_address" text,
+  "max_attendees"    integer NOT NULL DEFAULT 6,
+  "price_tiers"      jsonb NOT NULL DEFAULT '[{"min_count":1,"price_cents":12000}]'::jsonb,
+  "status"           text NOT NULL DEFAULT 'draft',
+  "itinerary_md"     text,
+  "itinerary_generated_at" timestamptz,
+  "created_by"       uuid,
+  "created_at"       timestamptz NOT NULL DEFAULT now(),
+  "updated_at"       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  "hosted_events" IS 'Operator-curated paid driver-mentor events. Distinct from discovered_events.';
+COMMENT ON COLUMN "hosted_events"."price_tiers" IS 'JSONB array of {min_count, price_cents} sorted ascending. computePrice() picks the largest tier whose min_count <= confirmed_count.';
+COMMENT ON COLUMN "hosted_events"."status" IS 'draft | published | closed | cancelled';
+
+CREATE INDEX IF NOT EXISTS "idx_hosted_events_published_date"
+  ON "hosted_events" ("status", "event_date")
+  WHERE "status" = 'published';
+
+CREATE TABLE IF NOT EXISTS "event_signups" (
+  "id"                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "event_id"              uuid NOT NULL REFERENCES "hosted_events"("id") ON DELETE CASCADE,
+  "full_name"             text NOT NULL,
+  "email"                 text NOT NULL,
+  "phone"                 text,
+  "pickup_address"        text,
+  "notes"                 text,
+  "status"                text NOT NULL DEFAULT 'confirmed',
+  "price_cents_at_signup" integer,
+  "created_at"            timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "event_signups_event_email_unique" UNIQUE ("event_id", "email")
+);
+
+COMMENT ON TABLE  "event_signups" IS 'Per-attendee row for hosted_events sign-up.';
+COMMENT ON COLUMN "event_signups"."status" IS 'confirmed | waitlist | cancelled';
+COMMENT ON COLUMN "event_signups"."price_cents_at_signup" IS 'Captured at signup time so the attendee knows the exact $ they committed to even if the displayed tiered price changes later.';
+
+CREATE INDEX IF NOT EXISTS "idx_event_signups_event_status_created"
+  ON "event_signups" ("event_id", "status", "created_at");

--- a/server/api/events/admin-events.js
+++ b/server/api/events/admin-events.js
@@ -1,0 +1,254 @@
+// server/api/events/admin-events.js
+// 2026-04-25: Admin endpoints (requireAuth) for hosted_events POC.
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+//
+// Routes (mounted at /api/admin/events, all requireAuth):
+//   GET    /                       → list ALL events incl. drafts
+//   POST   /                       → create event
+//   GET    /:id                    → event detail with full signup roster
+//   PATCH  /:id                    → update event
+//   DELETE /:id                    → delete event
+//   POST   /:id/generate-itinerary → AI itinerary from confirmed roster
+//   POST   /:id/promote-waitlist   → move oldest waitlist row to confirmed (if seat available)
+
+import express from 'express';
+import { getPool } from '../../db/connection-manager.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { computePrice } from '../../lib/events/pricing.js';
+import { generateItinerary } from '../../lib/events/itinerary.js';
+
+const router = express.Router();
+
+router.use(requireAuth);
+
+// GET /api/admin/events
+router.get('/', async (_req, res) => {
+  try {
+    const pool = getPool();
+    const { rows: events } = await pool.query(
+      `SELECT e.*,
+              (SELECT COUNT(*) FROM event_signups s WHERE s.event_id = e.id AND s.status = 'confirmed') AS confirmed_count,
+              (SELECT COUNT(*) FROM event_signups s WHERE s.event_id = e.id AND s.status = 'waitlist')  AS waitlist_count
+         FROM hosted_events e
+        ORDER BY e.event_date DESC, e.start_time DESC NULLS LAST`
+    );
+    res.json({ ok: true, events });
+  } catch (err) {
+    console.error('[admin-events] list error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to list events' });
+  }
+});
+
+// POST /api/admin/events
+router.post('/', async (req, res) => {
+  const {
+    slug, title, description,
+    event_date, start_time, end_time,
+    location_name, location_address,
+    max_attendees, price_tiers, status,
+  } = req.body || {};
+
+  if (!slug || !title || !event_date) {
+    return res.status(400).json({ ok: false, error: 'slug, title, event_date required' });
+  }
+
+  try {
+    const pool = getPool();
+    const { rows } = await pool.query(
+      `INSERT INTO hosted_events
+        (slug, title, description, event_date, start_time, end_time,
+         location_name, location_address, max_attendees, price_tiers, status, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       RETURNING *`,
+      [
+        slug, title, description || null,
+        event_date, start_time || null, end_time || null,
+        location_name || null, location_address || null,
+        max_attendees || 6,
+        JSON.stringify(price_tiers || [{ min_count: 1, price_cents: 12000 }]),
+        status || 'draft',
+        req.auth?.userId || null,
+      ]
+    );
+    res.json({ ok: true, event: rows[0] });
+  } catch (err) {
+    if (err.code === '23505') {
+      return res.status(409).json({ ok: false, error: 'slug already exists' });
+    }
+    console.error('[admin-events] create error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to create event' });
+  }
+});
+
+// GET /api/admin/events/:id
+router.get('/:id', async (req, res) => {
+  try {
+    const pool = getPool();
+    const { rows: events } = await pool.query(
+      `SELECT * FROM hosted_events WHERE id = $1`,
+      [req.params.id]
+    );
+    if (events.length === 0) {
+      return res.status(404).json({ ok: false, error: 'event not found' });
+    }
+    const event = events[0];
+    const { rows: signups } = await pool.query(
+      `SELECT * FROM event_signups WHERE event_id = $1 ORDER BY status, created_at ASC`,
+      [event.id]
+    );
+    const confirmedCount = signups.filter(s => s.status === 'confirmed').length;
+    res.json({
+      ok: true,
+      event: {
+        ...event,
+        current_price_cents: computePrice(event.price_tiers, confirmedCount),
+      },
+      signups,
+    });
+  } catch (err) {
+    console.error('[admin-events] detail error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to load event' });
+  }
+});
+
+// PATCH /api/admin/events/:id
+router.patch('/:id', async (req, res) => {
+  const allowed = [
+    'title', 'description',
+    'event_date', 'start_time', 'end_time',
+    'location_name', 'location_address',
+    'max_attendees', 'price_tiers', 'status',
+  ];
+  const sets = [];
+  const vals = [];
+  let i = 1;
+  for (const key of allowed) {
+    if (key in req.body) {
+      sets.push(`"${key}" = $${i++}`);
+      vals.push(key === 'price_tiers' ? JSON.stringify(req.body[key]) : req.body[key]);
+    }
+  }
+  if (sets.length === 0) return res.status(400).json({ ok: false, error: 'no fields to update' });
+  sets.push(`"updated_at" = now()`);
+  vals.push(req.params.id);
+
+  try {
+    const pool = getPool();
+    const { rows } = await pool.query(
+      `UPDATE hosted_events SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`,
+      vals
+    );
+    if (rows.length === 0) return res.status(404).json({ ok: false, error: 'event not found' });
+    res.json({ ok: true, event: rows[0] });
+  } catch (err) {
+    console.error('[admin-events] update error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to update event' });
+  }
+});
+
+// DELETE /api/admin/events/:id
+router.delete('/:id', async (req, res) => {
+  try {
+    const pool = getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM hosted_events WHERE id = $1`,
+      [req.params.id]
+    );
+    if (rowCount === 0) return res.status(404).json({ ok: false, error: 'event not found' });
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[admin-events] delete error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to delete event' });
+  }
+});
+
+// POST /api/admin/events/:id/generate-itinerary
+router.post('/:id/generate-itinerary', async (req, res) => {
+  try {
+    const pool = getPool();
+    const { rows: events } = await pool.query(
+      `SELECT * FROM hosted_events WHERE id = $1`,
+      [req.params.id]
+    );
+    if (events.length === 0) return res.status(404).json({ ok: false, error: 'event not found' });
+    const event = events[0];
+
+    const { rows: signups } = await pool.query(
+      `SELECT * FROM event_signups WHERE event_id = $1 AND status = 'confirmed' ORDER BY created_at ASC`,
+      [event.id]
+    );
+
+    const result = await generateItinerary(event, signups);
+    if (!result.ok) {
+      return res.status(502).json({ ok: false, error: result.error || 'itinerary generation failed' });
+    }
+
+    await pool.query(
+      `UPDATE hosted_events SET itinerary_md = $1, itinerary_generated_at = now(), updated_at = now() WHERE id = $2`,
+      [result.markdown, event.id]
+    );
+
+    res.json({ ok: true, itinerary_md: result.markdown });
+  } catch (err) {
+    console.error('[admin-events] itinerary error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to generate itinerary' });
+  }
+});
+
+// POST /api/admin/events/:id/promote-waitlist
+// Promotes the oldest waitlist row to confirmed if a seat is available.
+router.post('/:id/promote-waitlist', async (req, res) => {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: events } = await client.query(
+      `SELECT * FROM hosted_events WHERE id = $1 FOR UPDATE`,
+      [req.params.id]
+    );
+    if (events.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ ok: false, error: 'event not found' });
+    }
+    const event = events[0];
+
+    const { rows: cRows } = await client.query(
+      `SELECT COUNT(*) AS confirmed FROM event_signups WHERE event_id = $1 AND status = 'confirmed'`,
+      [event.id]
+    );
+    const confirmedCount = Number(cRows[0]?.confirmed || 0);
+    if (confirmedCount >= event.max_attendees) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ ok: false, error: 'event is full; cannot promote' });
+    }
+
+    const { rows: nextRows } = await client.query(
+      `SELECT * FROM event_signups
+        WHERE event_id = $1 AND status = 'waitlist'
+        ORDER BY created_at ASC LIMIT 1 FOR UPDATE`,
+      [event.id]
+    );
+    if (nextRows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ ok: false, error: 'waitlist is empty' });
+    }
+    const next = nextRows[0];
+
+    const newPrice = computePrice(event.price_tiers, confirmedCount + 1);
+    const { rows: updated } = await client.query(
+      `UPDATE event_signups SET status = 'confirmed', price_cents_at_signup = $1 WHERE id = $2 RETURNING *`,
+      [newPrice, next.id]
+    );
+
+    await client.query('COMMIT');
+    res.json({ ok: true, signup: updated[0] });
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error('[admin-events] promote error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to promote waitlist' });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/server/api/events/admin-events.js
+++ b/server/api/events/admin-events.js
@@ -12,6 +12,7 @@
 //   POST   /:id/promote-waitlist   → move oldest waitlist row to confirmed (if seat available)
 
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { getPool } from '../../db/connection-manager.js';
 import { requireAuth } from '../../middleware/auth.js';
 import { computePrice } from '../../lib/events/pricing.js';
@@ -19,7 +20,16 @@ import { generateItinerary } from '../../lib/events/itinerary.js';
 
 const router = express.Router();
 
+const adminEventsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: 'too many requests' },
+});
+
 router.use(requireAuth);
+router.use(adminEventsLimiter);
 
 // GET /api/admin/events
 router.get('/', async (_req, res) => {

--- a/server/api/events/public-events.js
+++ b/server/api/events/public-events.js
@@ -1,0 +1,194 @@
+// server/api/events/public-events.js
+// 2026-04-25: Public (no-auth) endpoints for the event sign-up POC.
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+//
+// Routes (mounted at /api/public/events):
+//   GET  /                  → list published events with current confirmed-count + price
+//   GET  /:slug             → single event detail
+//   POST /:slug/signup      → public signup (auto-assigns confirmed vs waitlist)
+
+import express from 'express';
+import { getPool } from '../../db/connection-manager.js';
+import { computePrice } from '../../lib/events/pricing.js';
+import { sendEventSignupAlert } from '../../lib/notifications/email-alerts.js';
+
+const router = express.Router();
+
+function isValidEmail(s) {
+  return typeof s === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+}
+
+async function loadEventCounts(pool, eventId) {
+  const { rows } = await pool.query(
+    `SELECT
+       COUNT(*) FILTER (WHERE status = 'confirmed') AS confirmed,
+       COUNT(*) FILTER (WHERE status = 'waitlist')  AS waitlist
+     FROM event_signups WHERE event_id = $1`,
+    [eventId]
+  );
+  return {
+    confirmed: Number(rows[0]?.confirmed || 0),
+    waitlist: Number(rows[0]?.waitlist || 0),
+  };
+}
+
+function decorateEvent(event, counts) {
+  const seatsLeft = Math.max(0, event.max_attendees - counts.confirmed);
+  return {
+    id: event.id,
+    slug: event.slug,
+    title: event.title,
+    description: event.description,
+    event_date: event.event_date,
+    start_time: event.start_time,
+    end_time: event.end_time,
+    location_name: event.location_name,
+    location_address: event.location_address,
+    max_attendees: event.max_attendees,
+    confirmed_count: counts.confirmed,
+    waitlist_count: counts.waitlist,
+    seats_left: seatsLeft,
+    is_full: seatsLeft === 0,
+    current_price_cents: computePrice(event.price_tiers, counts.confirmed),
+    price_tiers: event.price_tiers,
+    status: event.status,
+  };
+}
+
+// GET /api/public/events
+// Lists published, non-past events.
+router.get('/', async (_req, res) => {
+  try {
+    const pool = getPool();
+    const { rows: events } = await pool.query(
+      `SELECT * FROM hosted_events
+        WHERE status = 'published' AND event_date >= CURRENT_DATE
+        ORDER BY event_date ASC, start_time ASC NULLS LAST`
+    );
+    const decorated = await Promise.all(
+      events.map(async (e) => decorateEvent(e, await loadEventCounts(pool, e.id)))
+    );
+    res.json({ ok: true, events: decorated });
+  } catch (err) {
+    console.error('[public-events] list error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to list events' });
+  }
+});
+
+// GET /api/public/events/:slug
+router.get('/:slug', async (req, res) => {
+  try {
+    const pool = getPool();
+    const { rows } = await pool.query(
+      `SELECT * FROM hosted_events WHERE slug = $1 AND status = 'published' LIMIT 1`,
+      [req.params.slug]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ ok: false, error: 'event not found' });
+    }
+    const event = rows[0];
+    const counts = await loadEventCounts(pool, event.id);
+    res.json({ ok: true, event: decorateEvent(event, counts) });
+  } catch (err) {
+    console.error('[public-events] detail error:', err.message);
+    res.status(500).json({ ok: false, error: 'failed to load event' });
+  }
+});
+
+// POST /api/public/events/:slug/signup
+// Body: { full_name, email, phone?, pickup_address?, notes? }
+router.post('/:slug/signup', async (req, res) => {
+  const { full_name, email, phone, pickup_address, notes } = req.body || {};
+
+  if (!full_name || typeof full_name !== 'string' || full_name.trim().length < 2) {
+    return res.status(400).json({ ok: false, error: 'full_name required (min 2 chars)' });
+  }
+  if (!isValidEmail(email)) {
+    return res.status(400).json({ ok: false, error: 'valid email required' });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const { rows: eventRows } = await client.query(
+      `SELECT * FROM hosted_events WHERE slug = $1 AND status = 'published' FOR UPDATE`,
+      [req.params.slug]
+    );
+    if (eventRows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ ok: false, error: 'event not found or not open' });
+    }
+    const event = eventRows[0];
+
+    const counts = await loadEventCounts(client, event.id);
+    const status = counts.confirmed < event.max_attendees ? 'confirmed' : 'waitlist';
+    const priceCents = status === 'confirmed'
+      ? computePrice(event.price_tiers, counts.confirmed + 1)
+      : computePrice(event.price_tiers, event.max_attendees);
+
+    let signupRow;
+    try {
+      const { rows } = await client.query(
+        `INSERT INTO event_signups
+           (event_id, full_name, email, phone, pickup_address, notes, status, price_cents_at_signup)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING *`,
+        [
+          event.id,
+          full_name.trim(),
+          email.trim().toLowerCase(),
+          phone || null,
+          pickup_address || null,
+          notes || null,
+          status,
+          priceCents,
+        ]
+      );
+      signupRow = rows[0];
+    } catch (insertErr) {
+      if (insertErr.code === '23505') {
+        await client.query('ROLLBACK');
+        return res.status(409).json({
+          ok: false,
+          error: 'this email is already signed up for this event',
+        });
+      }
+      throw insertErr;
+    }
+
+    await client.query('COMMIT');
+
+    const newCounts = status === 'confirmed'
+      ? { confirmed: counts.confirmed + 1, waitlist: counts.waitlist }
+      : { confirmed: counts.confirmed, waitlist: counts.waitlist + 1 };
+
+    // Fire-and-forget email — never block the response on Resend.
+    sendEventSignupAlert({
+      event,
+      signup: signupRow,
+      confirmedCount: newCounts.confirmed,
+      maxAttendees: event.max_attendees,
+      priceCentsAtSignup: priceCents,
+    }).catch((e) => console.error('[public-events] alert error:', e.message));
+
+    res.json({
+      ok: true,
+      status,
+      price_cents: priceCents,
+      seats_left: Math.max(0, event.max_attendees - newCounts.confirmed),
+      message: status === 'confirmed'
+        ? "You're confirmed! Melody will be in touch by email."
+        : "The 6 confirmed seats are taken — you're on the waitlist. Melody will email if a seat opens up.",
+    });
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error('[public-events] signup error:', err.message);
+    res.status(500).json({ ok: false, error: 'signup failed' });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -110,6 +110,11 @@ export async function mountRoutes(app, server) {
     { path: '/api/hooks', module: './server/api/hooks/analyze-offer.js', desc: 'External Hooks (OCR/Signals)' },
     { path: '/api/hooks', module: './server/api/hooks/translate.js', desc: 'Siri Translation Hook' },
 
+    // Hosted Events (server/api/events/) — 2026-04-25: POC public event signup
+    // Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+    { path: '/api/public/events', module: './server/api/events/public-events.js', desc: 'Public Events (signup)' },
+    { path: '/api/admin/events',  module: './server/api/events/admin-events.js',  desc: 'Admin Events (CRUD + itinerary)' },
+
     // 2026-01-09: Removed EventEmitter SSE - DB NOTIFY SSE is canonical (mountSSE)
     // The /events mount was duplicating /events/strategy, /events/blocks with EventEmitter
     // while mountSSE() mounts DB-backed versions at same paths. See LESSONS_LEARNED.md.

--- a/server/lib/events/itinerary.js
+++ b/server/lib/events/itinerary.js
@@ -1,0 +1,61 @@
+// server/lib/events/itinerary.js
+// 2026-04-25: AI-assisted itinerary generation for paid mentor sessions.
+// Calls Anthropic Haiku directly via the existing adapter for low-latency admin UX.
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+
+import { callAnthropic } from '../ai/adapters/anthropic-adapter.js';
+
+const ITINERARY_MODEL = 'claude-haiku-4-5-20251001';
+
+/**
+ * Generate a markdown itinerary for an event roster.
+ * Pickup-route-and-timing plan keyed off attendee pickup addresses.
+ *
+ * @param {Object} event           hosted_events row
+ * @param {Array}  signups         confirmed event_signups rows
+ * @returns {Promise<{ok:boolean, markdown?:string, error?:string}>}
+ */
+export async function generateItinerary(event, signups) {
+  if (!event) return { ok: false, error: 'event required' };
+  if (!Array.isArray(signups) || signups.length === 0) {
+    return { ok: false, error: 'no confirmed signups to plan around' };
+  }
+
+  const system = [
+    'You are a logistics coordinator for a paid rideshare driver mentorship session.',
+    'Given an event location, time, and a roster of attendees with pickup addresses,',
+    'produce a concise pickup-and-route itinerary in markdown.',
+    'Sections: Summary, Pickup Order (with proposed pickup times), Route Notes, Contingencies.',
+    'Keep it actionable and short — operator will share verbatim with attendees.',
+    'Do NOT fabricate distances or drive times; describe order and relative timing only.',
+  ].join(' ');
+
+  const user = JSON.stringify({
+    event: {
+      title: event.title,
+      date: event.event_date,
+      start_time: event.start_time,
+      end_time: event.end_time,
+      location_name: event.location_name,
+      location_address: event.location_address,
+      description: event.description,
+    },
+    attendees: signups.map(s => ({
+      name: s.full_name,
+      pickup_address: s.pickup_address || null,
+      phone: s.phone || null,
+      notes: s.notes || null,
+    })),
+  }, null, 2);
+
+  const res = await callAnthropic({
+    model: ITINERARY_MODEL,
+    system,
+    user,
+    maxTokens: 2048,
+    temperature: 0.3,
+  });
+
+  if (!res.ok) return { ok: false, error: res.error || 'itinerary call failed' };
+  return { ok: true, markdown: res.output };
+}

--- a/server/lib/events/pricing.js
+++ b/server/lib/events/pricing.js
@@ -1,0 +1,35 @@
+// server/lib/events/pricing.js
+// 2026-04-25: POC event pricing — sliding cost-share by confirmed-attendee count.
+// Pure function. Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+
+/**
+ * Pick the per-person price (in cents) from a tiered cost-share schedule.
+ *
+ * Tier shape: { min_count: int, price_cents: int }
+ * Tiers describe "if at least N have confirmed, charge each person $X."
+ * The largest tier whose min_count <= confirmedCount wins.
+ *
+ * @param {Array<{min_count:number, price_cents:number}>} tiers
+ * @param {number} confirmedCount  number of currently-confirmed signups (waitlist excluded)
+ * @returns {number|null}  price in cents, or null if tiers are missing
+ */
+export function computePrice(tiers, confirmedCount) {
+  if (!Array.isArray(tiers) || tiers.length === 0) return null;
+  const sorted = [...tiers].sort((a, b) => a.min_count - b.min_count);
+  let chosen = sorted[0].price_cents;
+  for (const t of sorted) {
+    if (confirmedCount >= t.min_count) chosen = t.price_cents;
+    else break;
+  }
+  return chosen;
+}
+
+/**
+ * Format cents → "$NN.NN" for UI/email rendering.
+ * @param {number|null} cents
+ * @returns {string}
+ */
+export function formatUSD(cents) {
+  if (cents == null || Number.isNaN(cents)) return '—';
+  return `$${(cents / 100).toFixed(2)}`;
+}

--- a/server/lib/notifications/email-alerts.js
+++ b/server/lib/notifications/email-alerts.js
@@ -168,3 +168,76 @@ export async function sendTestEmail() {
     return { success: false, error: err.message };
   }
 }
+
+// 2026-04-25: Event signup alerts for hosted_events POC.
+// Plan: docs/plans/PLAN_event-signup-page-2026-04-25.md
+/**
+ * Notify Melody whenever someone signs up for a hosted event.
+ * @param {Object} params
+ * @param {Object} params.event        hosted_events row (title, slug, event_date, etc.)
+ * @param {Object} params.signup       new event_signups row
+ * @param {string} params.signup.status  'confirmed' | 'waitlist'
+ * @param {number} params.confirmedCount roster count after this signup landed
+ * @param {number} params.maxAttendees   event cap
+ * @param {number} params.priceCentsAtSignup price the attendee committed to
+ */
+export async function sendEventSignupAlert({
+  event,
+  signup,
+  confirmedCount,
+  maxAttendees,
+  priceCentsAtSignup,
+}) {
+  if (!resend) {
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('[email-alerts] Skipping signup alert (no API key):', signup?.email);
+    }
+    return { success: false, error: 'RESEND_API_KEY not configured' };
+  }
+
+  const isWaitlist = signup.status === 'waitlist';
+  const statusEmoji = isWaitlist ? '🕓' : '🎉';
+  const statusLabel = isWaitlist ? 'WAITLIST' : 'CONFIRMED';
+  const priceUSD = priceCentsAtSignup != null
+    ? `$${(priceCentsAtSignup / 100).toFixed(2)}`
+    : '—';
+
+  const subject = `${statusEmoji} New signup: ${event.title} — ${signup.full_name} (${statusLabel})`;
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2 style="color: ${isWaitlist ? '#f59e0b' : '#16a34a'};">${statusEmoji} ${statusLabel} — ${event.title}</h2>
+      <p style="color:#374151;">A new attendee just signed up.</p>
+
+      <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;width:160px;">Event:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${event.title} <small style="color:#6b7280;">(${event.event_date})</small></td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Name:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${signup.full_name}</td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Email:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;"><a href="mailto:${signup.email}">${signup.email}</a></td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Phone:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${signup.phone || '—'}</td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Pickup:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${signup.pickup_address || '—'}</td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Notes:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${signup.notes || '—'}</td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Status:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;"><strong>${statusLabel}</strong></td></tr>
+        <tr><td style="padding:6px;border-bottom:1px solid #e5e7eb;font-weight:bold;">Price committed:</td><td style="padding:6px;border-bottom:1px solid #e5e7eb;">${priceUSD}</td></tr>
+        <tr><td style="padding:6px;font-weight:bold;">Roster:</td><td style="padding:6px;">${confirmedCount} / ${maxAttendees} confirmed</td></tr>
+      </table>
+
+      <p style="color:#6b7280;font-size:12px;margin-top:16px;">
+        Manage attendees in the admin view: <code>/co-pilot/events-admin</code>
+      </p>
+    </div>
+  `;
+
+  try {
+    const result = await resend.emails.send({
+      from: 'onboarding@resend.dev',
+      to: ALERT_EMAIL,
+      subject,
+      html,
+    });
+    console.log(`📧 [EMAIL] Signup alert sent for ${signup.email}:`, result?.id);
+    return { success: true, id: result?.id };
+  } catch (err) {
+    console.error(`📧 [EMAIL] Signup alert failed:`, err.message);
+    return { success: false, error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary

Public event sign-up POC for Melody-curated paid driver-mentor sessions (the kind being promoted on Next Door). Distinct from `discovered_events` (system-discovered) — these are operator-curated paid events.

- Public list at `/events`, signup form at `/events/:slug` (no auth)
- Cap of 6 confirmed attendees per event, with auto-waitlist beyond that
- Dynamic per-person pricing: cost-share JSONB tiers — more signups → lower per-person price
- Email alert to `melodydashora@gmail.com` on every signup via existing Resend infra
- Admin view at `/co-pilot/events-admin` (auth-protected) to create/edit events, view roster, promote waitlist, generate AI itinerary
- AI itinerary uses **Claude Haiku 4.5** (fast model per request) — manual button, generates a markdown pickup-and-route plan from confirmed attendee addresses

Plan + test cases: `docs/plans/PLAN_event-signup-page-2026-04-25.md`

## Files
- `migrations/20260425_event_signup_poc.sql` — `hosted_events` + `event_signups`
- `server/lib/events/pricing.js` — pure tiered pricing function
- `server/lib/events/itinerary.js` — Haiku-backed itinerary generator
- `server/api/events/public-events.js` — public list/detail/signup
- `server/api/events/admin-events.js` — admin CRUD + itinerary + promote-waitlist
- `server/lib/notifications/email-alerts.js` — `sendEventSignupAlert()`
- `client/src/pages/events/{PublicEventsListPage,PublicEventSignupPage}.tsx`
- `client/src/pages/co-pilot/EventsAdminPage.tsx`
- Routes wired in `server/bootstrap/routes.js` and `client/src/routes.tsx`

## Non-goals (deferred to v2)
- **Square** payment integration (Melody uses Square, not Stripe). v1 is RSVP-only — Melody collects payment off-platform. v2 will add Square Invoices API inside the existing `sendEventSignupAlert` block; no schema change required.
- Auto-promotion of waitlist on cancellation (manual button for now)
- SMS notifications
- Per-attendee individual itineraries (one shared roster itinerary in v1)
- Recurring event templates

## Test plan (Melody to verify per Rule 1)

- [ ] **T1** — Run migration on dev DB; `\d hosted_events` and `\d event_signups` show schema
- [ ] **T2** — `GET /api/public/events` returns `{ events: [] }` initially
- [ ] **T3** — Admin creates event with 6 max + 3-tier pricing; appears in public list once `status='published'`
- [ ] **T4** — Sign up 6 attendees → all `confirmed`, 6 emails arrive, `price_cents_at_signup` matches the tier active at the moment they signed up
- [ ] **T5** — Sign up 7th attendee → status `waitlist`, email arrives flagged WAITLIST
- [ ] **T6** — Duplicate email for same event → 409 with friendly error, no email sent
- [ ] **T7** — Admin clicks "Generate Itinerary" with 4 confirmed signups → markdown returned + persisted; visible in admin
- [ ] **T8** — Admin clicks "Promote next from waitlist" → first waitlist row → confirmed; price recomputed
- [ ] **T9** — `npm run typecheck` and `npm run build` both clean (verified locally — no source-file errors; only pre-existing `@types/node` and `vite/client` infra warnings)
- [ ] **T10** — Visit `/events` and `/events/<slug>` while signed out — pages render publicly
- [ ] **T11** — Visit `/co-pilot/events-admin` while signed out — redirected to sign-in

## Notes
- Pre-approved as POC ("ship asap, public, fastest model")
- Per CLAUDE.md Rule 1, this PR stays in **draft** until Melody runs T1–T11 and replies "all tests passed"
- Per CLAUDE.md Rule 13, run the migration on **dev** first; prod migration needs a separate explicit approval
- Resend is already configured to alert `melodydashora@gmail.com` — no new env vars required
- The Anthropic adapter requires `ANTHROPIC_API_KEY` (already present per existing AI infra)

https://claude.ai/code/session_015z7AuUoDPUXxbxsfaSc5Db