### PR TITLE
fix(test): escape unescaped dot in Places hostname regex (CodeQL #199)

### DIFF
--- a/tests/strategy/tactical-planner-cache.test.js
+++ b/tests/strategy/tactical-planner-cache.test.js
@@ -183,7 +183,7 @@ describe('resolveVenueWithCache — cache miss path (falls through to Places API
     expect(fetchSpy).toHaveBeenCalled();
     // First fetch call should hit the Places text search URL
     const firstCallUrl = fetchSpy.mock.calls[0][0];
-    expect(firstCallUrl).toMatch(/places.googleapis\.com/);
+    expect(firstCallUrl).toMatch(/places\.googleapis\.com/);
     expect(result).toBeNull();  // Places returned no matches
 
     fetchSpy.mockRestore();


### PR DESCRIPTION
## Summary
Addresses the CodeQL finding from PR #27 review [4216385543](https://github.com/melodydashora/Vecto-Pilot/pull/27#pullrequestreview-4216385543).

`tests/strategy/tactical-planner-cache.test.js:186` had an incomplete hostname regex:

```diff
- expect(firstCallUrl).toMatch(/places.googleapis\.com/);
+ expect(firstCallUrl).toMatch(/places\.googleapis\.com/);
```

The unescaped `.` between `places` and `googleapis` was a regex metacharacter matching any single character (e.g. `placesXgoogleapis.com`), while the dot before `com` was already correctly escaped. The fix is purely defensive — the actual asserted URL contains a literal `.`, so test behavior is unchanged.

## Why fix this in a test
CodeQL flags hostname regex laxity as a class because patterns routinely migrate from tests/fixtures into production allowlists, CSP headers, or SSRF defenses. Catching it at the test layer prevents the same mistake from landing in security-sensitive code later.

## Test plan
- [x] One-line change is a strict tightening of the regex; every string the new pattern matches, the old pattern also matched. The literal URL `https://places.googleapis.com/v1/places:searchText` that the test asserts against still matches.
- [x] Local jest run skipped — `node_modules/jest` is not installed in this workspace; the upstream test suite (per PR #27 description) was already passing on this assertion before the fix.
- [x] CodeQL alert #199 should auto-close once this lands on `main` and the next scan completes.

## Files
- Modified: `tests/strategy/tactical-planner-cache.test.js` (1 line)

> Note: intended to be opened as a draft, but the MCP wrapper rejected the `draft` boolean parameter. Convert to draft via the GitHub UI if desired, or leave as-is for review.

https://claude.ai/code/session_014wXHGuDgBKGTpvh1cpEgng


---
_Generated by [Claude Code](https://claude.ai/code/session_014wXHGuDgBKGTpvh1cpEgng)_