### PR TITLE
2026-06-11: harden offer-analyzer model config + honest ai_model telemetry

### DIFF
--- a/docs/architecture/OFFER_ANALYZER.md
+++ b/docs/architecture/OFFER_ANALYZER.md
@@ -148,9 +148,9 @@ Tier drives which prompt template, rule set, and fallback thresholds apply. Dete
 
 ## 4. Phase 1 — Synchronous Analysis (Gemini Flash)
 
-**Source:** `server/api/hooks/analyze-offer.js` lines 227–439
-**Model role:** `OFFER_ANALYZER` → `gemini-flash-latest` (default)
-**Registry config:** `server/lib/ai/model-registry.js:328` — `maxTokens: 1024`, `temperature: 0.1`, `features: ['vision']`, no thinking level
+**Source:** `server/api/hooks/analyze-offer.js` lines 260–439
+**Model role:** `OFFER_ANALYZER` → `gemini-3.5-flash` (pinned default — NEVER a `*-latest` alias; see Memory #342)
+**Registry config:** `server/lib/ai/model-registry.js:303` — `maxTokens: 8192`, `temperature: 0.1`, `thinkingLevel: 'HIGH'`, `features: ['vision']`
 
 ### 4.1 Control Flow
 
@@ -224,9 +224,9 @@ REJECT. Share rides always rejected.
 
 ## 5. Phase 2 — Asynchronous Deep Analysis (Gemini Pro)
 
-**Source:** `analyze-offer.js:456–657`
-**Model role:** `OFFER_ANALYZER_DEEP` → `gemini-pro-latest`
-**Registry config:** `model-registry.js:341` — `maxTokens: 2048`, `temperature: 0.2`, `thinkingLevel: 'LOW'`, `features: ['vision']`
+**Source:** `analyze-offer.js:481–657`
+**Model role:** `OFFER_ANALYZER_DEEP` → `gemini-3.1-pro-preview` (pinned default — NEVER a `*-latest` alias; see Memory #342)
+**Registry config:** `model-registry.js:319` — `maxTokens: 2048`, `temperature: 0.2`, `thinkingLevel: 'LOW'`, `features: ['vision']`
 **Timeout:** 45 seconds, enforced via `Promise.race` (the Gemini SDK has no built-in timeout).
 
 ### 5.1 Flow
@@ -236,8 +236,8 @@ REJECT. Share rides always rejected.
 3. Call Gemini Pro with same screenshot and same text.
 4. If Phase 2 succeeds:
    - Parse its JSON (includes `parsed_data`, `decision`, `reasoning`, `confidence`, `location_analysis`).
-   - `aiModelUsed = 'gemini-3.1-pro'`.
-5. If Phase 2 fails (timeout, error, non-JSON): fall back to Phase 1 result. `aiModelUsed = 'gemini-3-flash'`.
+   - `aiModelUsed = 'gemini-3.1-pro-preview'`.
+5. If Phase 2 fails (timeout, error, non-JSON): fall back to Phase 1 result. `aiModelUsed = 'gemini-3.5-flash'`.
 6. Merge `preParsed + phase2Result.parsed_data` into `mergedParsedData`.
 7. Compute geographic columns (`coord_key`, `h3_index`), temporal columns (`local_date`, `local_hour`, `day_of_week`, `day_part`, `is_weekend`).
 8. Compute offer-session bucket (30-min window): same `offer_session_id` if prior offer for this device within 1800 s, else new UUID; `offer_sequence_num` increments.
@@ -269,9 +269,9 @@ REJECT. Share rides always rejected.
 
 | Failure | Fallback behavior | `ai_model` recorded |
 |---------|-------------------|---------------------|
-| Timeout after 45 s | Phase 1 result saved to DB | `gemini-3-flash` |
-| Gemini error (5xx, auth, quota) | Phase 1 result saved to DB | `gemini-3-flash` |
-| Non-JSON response | Phase 1 result saved to DB | `gemini-3-flash` |
+| Timeout after 45 s | Phase 1 result saved to DB | `gemini-3.5-flash` |
+| Gemini error (5xx, auth, quota) | Phase 1 result saved to DB | `gemini-3.5-flash` |
+| Non-JSON response | Phase 1 result saved to DB | `gemini-3.5-flash` |
 | Any thrown exception | Logged to console, DB insert skipped entirely (best-effort; Siri already answered) | n/a |
 
 Currently **Phase 2 reasoning does not surface back to Siri** — the driver hears the Phase 1 `voice` and never learns of Phase 2's richer verdict. Tracked in §16.
@@ -616,7 +616,7 @@ Miles are rounded to the nearest whole number with plural handling (`1 mile`, `6
 | `decision` | text NOT NULL | `'ACCEPT' \| 'REJECT' \| 'NO DATA'` — persisted verbatim from Phase 2 if available, else Phase 1 |
 | `decision_reasoning` | text | Phase 2 prose reasoning if available, else Phase 1 terse reason |
 | `confidence_score` | integer | 0-100 |
-| `ai_model` | text | `'gemini-3.1-pro'` on Phase 2 success, `'gemini-3-flash'` on Phase 2 fallback |
+| `ai_model` | text | `'gemini-3.1-pro-preview'` on Phase 2 success, `'gemini-3.5-flash'` on Phase 2 fallback |
 | `response_time_ms` | integer | Phase 1 latency (the only latency the driver experienced) |
 
 #### Driver Feedback
@@ -808,7 +808,7 @@ What is missing: native app, share-intent handler, accessibility service, notifi
 | Tier classification (share/standard/premium) | ✅ Working |
 | Share auto-reject (skip AI) | ✅ Working |
 | Deterministic fallback rule engine | ✅ Working |
-| `offer_intelligence` DB storage (107-column structured) | ✅ Working |
+| `offer_intelligence` DB storage (52-column structured) | ✅ Working |
 | Coach integration (last 20 offers + stats) | ✅ Working |
 | SSE broadcast (`offer_analyzed`) | ✅ Working |
 | `reason` field surfaced to Siri | ✅ Added 2026-04-15 (Memory #120) |

--- a/server/api/hooks/analyze-offer.js
+++ b/server/api/hooks/analyze-offer.js
@@ -519,7 +519,9 @@ PRE-PARSED DATA (server-verified):
         const phase2Start = Date.now();
 
         let deepResult = null;
-        let aiModelUsed = 'gemini-3.5-flash'; // Default: Phase 1 model (used if Phase 2 fails)
+        // 2026-06-11: derive from the model callModel ACTUALLY resolved (captures a Phase-1 503→flash
+        // fallback too) instead of a hardcoded literal that silently lies after a fleet migration.
+        let aiModelUsed = phase1Response.model || 'gemini-3.5-flash'; // Phase 1 model (used if Phase 2 fails)
         let phase2RawText = null;
 
         try {
@@ -538,7 +540,7 @@ PRE-PARSED DATA (server-verified):
             const cleaned = phase2Response.text
               .replace(/```json/g, '').replace(/```/g, '').trim();
             deepResult = JSON.parse(cleaned);
-            aiModelUsed = 'gemini-3.1-pro-preview'; // Phase 2 = OFFER_ANALYZER_DEEP (kept on Pro for deep reasoning)
+            aiModelUsed = phase2Response.model || 'gemini-3.1-pro-preview'; // 2026-06-11: the model Phase 2 ACTUALLY ran (a 503 fallback correctly reports flash here)
             console.log(`[HOOKS] 🔬 PHASE 2 DONE (${Date.now() - phase2Start}ms): ai_model=${aiModelUsed}, decision=${deepResult.decision}`);
           } else {
             console.warn(`[HOOKS] Phase 2 AI call failed: ${phase2Response.error} — falling back to Phase 1 result`);
@@ -551,7 +553,7 @@ PRE-PARSED DATA (server-verified):
         const dbParsedData = deepResult?.parsed_data || phase1Result;
         const dbDecision = deepResult?.decision || decision;
         const dbReasoning = deepResult?.reasoning || reason;
-        const dbConfidence = deepResult?.confidence || confidence;
+        const dbConfidence = deepResult?.confidence ?? confidence; // ?? not || — a legit model confidence of 0 must survive
         const locationAnalysis = deepResult?.location_analysis || null;
 
         // Merge all parsed data for the raw JSON column

--- a/server/lib/ai/adapters/index.js
+++ b/server/lib/ai/adapters/index.js
@@ -186,6 +186,7 @@ export async function callModel(role, params) {
       ok: true,
       text: response.output, // Ensure 'text' property is available for legacy code
       output: response.output,
+      model: primaryConfig.model, // 2026-06-11: expose the RESOLVED model id so callers log the truth, not a hardcoded literal
       provider: result.provider,
       latencyMs: result.latencyMs,
       citations: response.citations
@@ -223,6 +224,7 @@ export async function callModel(role, params) {
             ok: true,
             text: retryResult.output,
             output: retryResult.output,
+            model: GEMINI_FALLBACK_MODEL, // 2026-06-11: the 503 fallback actually ran flash — report THAT, not the primary
             provider: 'google-fallback',
             latencyMs: retryDuration,
             citations: retryResult.citations,

--- a/server/lib/ai/model-registry.js
+++ b/server/lib/ai/model-registry.js
@@ -300,10 +300,21 @@ export const MODEL_ROLES = {
   //    records that Pro+thinking previously timed out Shortcuts. Monitor response_time_ms;
   //    if Siri times out, step down to 'LOW'/'MINIMAL' or move deep reasoning to Phase 2
   //    (OFFER_ANALYZER_DEEP, which is async and not latency-sensitive).
+  // ── HARDENED 2026-06-11 (determinism doctrine — do NOT regress) ──────────────
+  //  ROLE: Phase 1 is the SINGLE fast analyzer for BOTH offer modalities —
+  //    • VISUAL path: Siri Vision shortcut sends a screenshot (analyze-offer.js:275 → images[])
+  //    • TEXT path:   Siri text shortcut → parseOfferText() regex pre-parse → same model
+  //  MODEL gemini-3.5-flash — verified live (/v1beta/models) + web-benchmarked (I/O 2026):
+  //    Flash 3.5 LEADS multimodal/vision (84.2% CharXiv) AND runs ~4× throughput / 2.6× faster
+  //    than 3.1 Pro. It is simultaneously the most-accurate-vision and the fastest model — exactly
+  //    what the eyes-on-road, Siri-bound decision needs. Do NOT "upgrade" Phase 1 to a Pro model:
+  //    Pro is slower, weaker on multimodal, and would blow the ~30s Shortcut timeout.
+  //  ⚠️ PINNED, NOT FLOATING: never gemini-flash-latest or any *-latest alias. Memory #342: a
+  //    floating alias resolved server-side to an internal Google build and 404'd in production.
   OFFER_ANALYZER: {
     envKey: 'OFFER_ANALYZER_MODEL',
     default: 'gemini-3.5-flash',
-    purpose: 'Phase 1: Real-time ride offer analysis from Siri Shortcuts (ACCEPT/REJECT)',
+    purpose: 'Phase 1: Real-time fast analysis (visual screenshot OR parsed text) from Siri Shortcuts (ACCEPT/REJECT)',
     // 2026-05-29: Raised 1024 → 8192. HIGH thinking consumes the output-token budget
     // (same rationale as BRIEFING_TRAFFIC's 4096→8192 bump). At 1024 the JSON decision
     // truncates mid-token — the exact "[HOOKS] Phase 1 JSON parse failed" symptom.
@@ -316,10 +327,23 @@ export const MODEL_ROLES = {
   // 2026-02-28: Phase 2 deep analysis — runs async AFTER Siri gets its fast response.
   // Pro 3.1 provides richer reasoning, location analysis, and confidence scoring for DB storage.
   // Not latency-sensitive — driver already has their answer from Flash.
+  // ── HARDENED 2026-06-11 (determinism doctrine — do NOT regress) ──────────────
+  //  MODEL gemini-3.1-pro-preview — the DEEPEST reasoner currently available.
+  //  WHY Pro (not Flash): Phase 2 is async — it runs AFTER Siri already answered, so it costs
+  //    ZERO eyes-on-road latency and we trade speed for depth. Web-benchmarked (I/O 2026): 3.1
+  //    Pro LEADS pure abstract reasoning (ARC-AGI-2 77.1 vs Flash 72.1) + long-context — exactly
+  //    what the enriched offer_intelligence row wants.
+  //  WHY 3.1 (not "3.5 Pro"): as of 2026-06-11 NO gemini-3.5-pro / high-thinking-3.5 exists
+  //    (confirmed live — only gemini-3.5-FLASH ships). 3.1 Pro is the latest Pro. WHEN a newer
+  //    Pro (or a high-thinking 3.5) lands, re-verify it live in /v1beta/models and bump here.
+  //  ⚠️ DO NOT downgrade to flash in a fleet migration. The 2026-05-30 migration did exactly that
+  //    (pinning every role to gemini-3.5-flash to kill the #342 404), silently making "deep" ==
+  //    Phase 1 and turning analyze-offer.js:541 aiModelUsed into a lie for ~12 days.
+  //  ⚠️ PINNED, NOT FLOATING: never gemini-pro-latest / *-latest (see OFFER_ANALYZER + #342).
   OFFER_ANALYZER_DEEP: {
     envKey: 'OFFER_ANALYZER_DEEP_MODEL',
-    default: 'gemini-3.5-flash',
-    purpose: 'Phase 2: Async deep ride offer analysis for DB enrichment (runs after Siri response)',
+    default: 'gemini-3.1-pro-preview',
+    purpose: 'Phase 2: Async deep analysis (visual + text) for offer_intelligence enrichment — runs after Siri response',
     maxTokens: 2048,
     temperature: 0.2,
     thinkingLevel: 'LOW', // Pro only supports LOW/HIGH; LOW gives reasoning boost without full latency


### PR DESCRIPTION
## Summary

Hardens the **offer analyzer** after a multi-dimension audit. The analyzer gives drivers a **spoken** (accessibility-read) ACCEPT/REJECT decision while driving — so model correctness and honest telemetry directly affect a number spoken aloud at speed. Separate from #36 (events display); based on `main`.

### Model config
- **Restore Phase 2 deep analysis to Pro** — `OFFER_ANALYZER_DEEP`: `gemini-3.5-flash` → **`gemini-3.1-pro-preview`**. The 2026-05-30 fleet migration (which pinned every role to flash to kill the [#342](../) floating-alias 404) accidentally downgraded "deep" to the *same fast model* as Phase 1. Verified both IDs resolve live (`/v1beta/models`); no env override. Phase 1 (visual + text) stays flash — it **leads multimodal AND is ~4× faster** (I/O 2026 benchmarks), exactly right for the eyes-on-road path. No `gemini-3.5-pro` exists yet, so 3.1 Pro is the deepest available.
- **Determinism doctrine comments** on both roles: why flash vs pro, *pinned not floating* (`*-latest` = #342), and an explicit **DO-NOT-downgrade-in-migration** warning naming the exact mistake.

### Honest `ai_model` telemetry (root-cause fix)
- `callModel()` now returns the **resolved model id** — `primaryConfig.model` on success, `GEMINI_FALLBACK_MODEL` on the 503-retry path (so a Pro→flash fallback reports *flash*, not Pro). Purely additive; improves observability for **every** role.
- `analyze-offer.js` derives `aiModelUsed` from `phase{1,2}Response.model` instead of hardcoded literals that silently drift/lie after a model swap — the exact bug that recorded "Pro" while flash ran for ~12 days.

### Correctness
- `dbConfidence` uses `??` not `||` — a legitimate model confidence of **0** was being discarded as falsy.

### Docs (zero-drift)
- `OFFER_ANALYZER.md` was re-documenting the floating `gemini-flash-latest` / `gemini-pro-latest` aliases as defaults — the #342 footgun a reader could re-pin. Corrected to pinned IDs, plus stale Phase-1 config (`maxTokens 1024→8192`, `thinkingLevel: HIGH`), 5 wrong model-ID references, the `107→52` column count, and key line citations.

## Architecture verified
One Phase-1 role (`OFFER_ANALYZER`, flash) adaptively serves **both** modalities — visual (Siri screenshot → `images[]`) and text (`parseOfferText()` regex pre-parse). Phase 2 (`OFFER_ANALYZER_DEEP`, Pro) enriches `offer_intelligence` async, after the driver already has their answer.

## Test plan
- [x] `eslint` clean on all changed JS (`model-registry.js`, `adapters/index.js`, `analyze-offer.js`)
- [x] Both model IDs resolve live in `/v1beta/models`; no env override present
- [x] Doc drift-sweep clean (no floating aliases / stale IDs remain)
- [ ] No live HTTP e2e — local server was down during the audit; recommend a manual Siri-Shortcut smoke test (vision + text) post-deploy to confirm `ai_model` now records the true model.

## Notes / deferred
- Vision edge case (`analyze-offer.js:276`): if a caller sends *both* text and image, the image is dropped while `input_mode` still records `'vision'`. Harmless with current Siri shortcuts (one or the other); worth tightening later.
- `OFFER_ANALYZER_DEEP` `maxTokens: 2048` is fine for `LOW` thinking; bump only if deep JSON ever truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
