### PR TITLE
2026-06-11: read-only prod query bridge for terminal monitoring (security-reviewed)

### DIFF
--- a/docs/architecture/PROD_QUERY_BRIDGE.md
+++ b/docs/architecture/PROD_QUERY_BRIDGE.md
@@ -1,0 +1,65 @@
+# Prod Query Bridge (read-only)
+
+> Lets the terminal dev agent (Claude Code) **monitor and analyze production data** without a direct DB connection. On current Replit infrastructure the prod database is **app-scoped** — only the deployed app's runtime can reach it; psql / external clients cannot (see `DATABASE_ENVIRONMENTS.md` and `claude_memory #351`). So the agent talks to the deployed **app** over HTTPS, and the app reaches prod.
+
+## Security model — capability, not validation
+
+- **Auth:** every route requires an agent/bridge token (`x-claude-bridge-token` → `CLAUDE_BRIDGE_TOKEN`, or `x-vecto-agent-secret` → `VECTO_AGENT_SECRET`), constant-time compared (`requireAgentOnly` in `server/middleware/auth.js`). No end-user session can reach these routes.
+- **Structured** `GET /api/admin/offer-monitor`: fixed Drizzle `SELECT`s only → **zero user-SQL surface**. Runs on the app pool. Safe by construction.
+- **Raw** `POST /api/admin/query`: arbitrary `SELECT`, but executed under a **dedicated read-only role** (`VECTO_READONLY_DATABASE_URL`) that *physically* cannot write or read non-allowlisted tables. Plus per-transaction `SET TRANSACTION READ ONLY`, `statement_timeout`, a single-statement / `SELECT`|`WITH`-prefix check, and a 1000-row cap. If the read-only role is **not** configured, raw query is **disabled (503)** — it never falls back to the app's full-privilege pool.
+
+The role — not a regex — is the guarantee. The string checks are defense-in-depth.
+
+## One-time setup
+
+Run on **PROD** via the Replit Database tool → **Production** → SQL runner:
+
+```sql
+CREATE ROLE vecto_readonly WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD '<strong-password>';
+GRANT CONNECT ON DATABASE <prod_db> TO vecto_readonly;
+GRANT USAGE  ON SCHEMA public TO vecto_readonly;
+-- allowlist: analytical tables only
+GRANT SELECT ON offer_intelligence, zone_intelligence, discovered_events,
+                coach_conversations, coach_memos TO vecto_readonly;
+ALTER ROLE vecto_readonly SET statement_timeout = '10000';                 -- 10s hard cap
+ALTER ROLE vecto_readonly SET default_transaction_read_only = on;          -- belt: never writes
+ALTER ROLE vecto_readonly SET idle_in_transaction_session_timeout = '15000';
+```
+
+**Harden against `PUBLIC`-granted functions** (a fresh role inherits `PUBLIC` EXECUTE on built-ins, which the table allowlist does not cover):
+- `pg_sleep` and other heavy functions are bounded by the 10s `statement_timeout` (so the DoS is capped at one connection for 10s).
+- `pg_read_file` / `COPY ... PROGRAM` require superuser or `pg_read_server_files` — the `NOSUPERUSER` role has neither, so they're already blocked.
+- The one real residual vector is network-reaching **extensions** (`dblink`, `http`) *if installed*. On a stock Neon/Replit prod they aren't. If they are, revoke them: `REVOKE EXECUTE ON FUNCTION dblink(text, text) FROM PUBLIC;` (each overload). **Note:** `REVOKE … FROM PUBLIC` affects *all* roles — coordinate before running.
+
+Then set secrets:
+
+| Secret | Where | Purpose |
+|--------|-------|---------|
+| `VECTO_READONLY_DATABASE_URL` = `postgres://vecto_readonly:<pw>@<prod-host>/<db>?sslmode=require` | **Deployment** | the read-only role the raw `/query` runs under |
+| `CLAUDE_BRIDGE_TOKEN` | **Deployment** (validate) + **dev workspace** (sign) | bridge auth |
+
+> To add `VECTO_READONLY_DATABASE_URL` to the deployment: Deployments pane → Secrets. (Workspace secrets do **not** carry to the deployment.)
+
+## Usage (from the dev terminal)
+
+```bash
+# Structured monitor (no raw SQL) — fleet-wide recent offers + stats:
+node scripts/query-prod.js --monitor --limit=20
+
+# Raw read-only SELECT:
+node scripts/query-prod.js "SELECT created_at, ai_model, decision, confidence_score \
+  FROM offer_intelligence ORDER BY created_at DESC LIMIT 10"
+
+# Write JSON to a file for local analysis:
+node scripts/query-prod.js --monitor --out=temp/prod-eval.json
+```
+
+> For deep multi-table analysis, pull to a JSON file and analyze **locally** — do **not** sync prod rows into the dev DB (breaks dev/prod isolation + driver-PII risk). The deliberately-dropped "sync prod→dev" idea is tracked in `todo #6`.
+
+## Coach-memo access
+
+`coach_memos` is in the allowlist specifically because the Coach writes memos to **prod**, while `npm run pull-coach-memos` reads the **dev** `DATABASE_URL` — so prod memos never reach the dev terminal that way. Use the bridge instead:
+
+```bash
+node scripts/query-prod.js "SELECT created_at, type, title, detail FROM coach_memos ORDER BY created_at DESC LIMIT 20"
+```

--- a/scripts/query-prod.js
+++ b/scripts/query-prod.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/query-prod.js — terminal client for the PROD read-only query bridge.
+//
+// WHY: prod (current Replit infra) is app-scoped — the dev terminal can't reach the
+// prod DB directly. This script calls the deployed app's read-only bridge over HTTPS.
+// See docs/architecture/PROD_QUERY_BRIDGE.md.
+//
+// Usage:
+//   node scripts/query-prod.js --monitor [--limit=50]                       structured offer monitor
+//   node scripts/query-prod.js "SELECT ai_model, decision FROM offer_intelligence LIMIT 10"   raw read-only SELECT
+//   node scripts/query-prod.js --monitor --out=temp/prod-eval.json          also write JSON to a file
+//
+// Auth: signs with CLAUDE_BRIDGE_TOKEN (or VECTO_AGENT_SECRET) from the local env.
+// Target host defaults to https://vectopilot.com (override with VECTO_PROD_BASE_URL).
+
+import fs from 'node:fs/promises';
+
+const BASE = process.env.VECTO_PROD_BASE_URL || 'https://vectopilot.com';
+const TOKEN = process.env.CLAUDE_BRIDGE_TOKEN || process.env.VECTO_AGENT_SECRET;
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (const a of argv) {
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      args[k] = v === undefined ? true : v;
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+async function main() {
+  if (!TOKEN) {
+    console.error('Missing CLAUDE_BRIDGE_TOKEN (or VECTO_AGENT_SECRET) in the environment.');
+    process.exit(1);
+  }
+  const args = parseArgs(process.argv.slice(2));
+  const headers = { 'x-claude-bridge-token': TOKEN, 'content-type': 'application/json' };
+
+  let url;
+  let init;
+  if (args.monitor) {
+    const q = args.limit ? `?limit=${encodeURIComponent(args.limit)}` : '';
+    url = `${BASE}/api/admin/offer-monitor${q}`;
+    init = { method: 'GET', headers };
+  } else {
+    const sqlText = args._.join(' ').trim();
+    if (!sqlText) {
+      console.error('Provide a SELECT query, or use --monitor.');
+      process.exit(1);
+    }
+    url = `${BASE}/api/admin/query`;
+    init = { method: 'POST', headers, body: JSON.stringify({ sql: sqlText }) };
+  }
+
+  const resp = await fetch(url, init);
+  const text = await resp.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { raw: text }; }
+
+  if (!resp.ok) {
+    console.error(`HTTP ${resp.status}:`, JSON.stringify(json, null, 2));
+    process.exit(1);
+  }
+
+  const pretty = JSON.stringify(json, null, 2);
+  console.log(pretty);
+  if (args.out) {
+    await fs.writeFile(args.out, pretty);
+    console.error(`\n→ wrote ${args.out}`);
+  }
+}
+
+main().catch((e) => {
+  console.error('query-prod failed:', e.message);
+  process.exit(1);
+});

--- a/server/api/admin/monitor.js
+++ b/server/api/admin/monitor.js
@@ -1,0 +1,166 @@
+// server/api/admin/monitor.js
+// Read-only PRODUCTION observability bridge for the terminal dev agent.
+//
+// WHY THIS EXISTS: on current Replit infrastructure the prod database is app-scoped —
+// only the deployed app's runtime can reach it (psql/external clients cannot). So the
+// dev agent monitors prod by calling THESE endpoints over HTTPS; the app reaches prod
+// via Drizzle (structured) or a dedicated read-only pool (raw). See
+// docs/architecture/PROD_QUERY_BRIDGE.md and claude_memory #351.
+//
+// SECURITY MODEL — capability, not validation:
+//   - ALL routes require an agent/bridge token (requireAgentOnly) — no end-user sessions.
+//   - GET /offer-monitor: FIXED Drizzle SELECTs only → zero user-SQL surface.
+//   - POST /query: arbitrary SELECT, but executed under a DEDICATED READ-ONLY ROLE
+//     (VECTO_READONLY_DATABASE_URL) whose GRANTs allow SELECT only on allowlisted
+//     analytical tables, with statement_timeout + default_transaction_read_only. The
+//     ROLE — not a regex — is the guarantee. The code checks (single-statement,
+//     SELECT/WITH prefix, row cap, per-txn READ ONLY) are defense-in-depth. If the
+//     read-only role is not configured, raw /query is DISABLED (503) and NEVER falls
+//     back to the app's full-privilege pool.
+
+import express, { Router } from 'express';
+import pkg from 'pg';
+import { sql } from 'drizzle-orm';
+import { db } from '../../db/drizzle.js';
+import { offer_intelligence } from '../../../shared/schema.js';
+import { requireAgentOnly } from '../../middleware/auth.js';
+
+const { Pool } = pkg;
+const router = Router();
+
+// Auth first (reject unauthenticated before parsing a body), then JSON parsing.
+router.use(requireAgentOnly);
+router.use(express.json({ limit: '64kb' }));
+
+const MAX_ROWS = 1000;
+const STMT_TIMEOUT_MS = 10000;
+
+// ─── Dedicated READ-ONLY pool (raw /query only — NEVER the app pool) ──────────
+let roPool = null;
+function getReadonlyPool() {
+  if (!process.env.VECTO_READONLY_DATABASE_URL) return null;
+  if (!roPool) {
+    roPool = new Pool({
+      connectionString: process.env.VECTO_READONLY_DATABASE_URL,
+      max: 3,
+      connectionTimeoutMillis: 5000,        // 2026-06-11: never queue forever if the RO DB is unreachable
+      statement_timeout: STMT_TIMEOUT_MS,
+      idle_in_transaction_session_timeout: 15000,
+    });
+  }
+  return roPool;
+}
+
+// ─── GET /api/admin/offer-monitor ─────────────────────────────────────────────
+// Fleet-wide recent offers + aggregate stats. Fixed Drizzle query (no user SQL).
+router.get('/offer-monitor', async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 500);
+    const rows = await db
+      .select({
+        id: offer_intelligence.id,
+        created_at: offer_intelligence.created_at,
+        input_mode: offer_intelligence.input_mode,
+        decision: offer_intelligence.decision,
+        ai_model: offer_intelligence.ai_model,
+        response_time_ms: offer_intelligence.response_time_ms,
+        confidence_score: offer_intelligence.confidence_score,
+        parse_confidence: offer_intelligence.parse_confidence,
+        per_mile: offer_intelligence.per_mile,
+        total_miles: offer_intelligence.total_miles,
+        product_type: offer_intelligence.product_type,
+      })
+      .from(offer_intelligence)
+      .orderBy(sql`created_at DESC`)
+      .limit(limit);
+
+    const byModel = {};
+    const byDecision = {};
+    let latencySum = 0;
+    let latencyN = 0;
+    for (const r of rows) {
+      const m = r.ai_model || 'unknown';
+      const d = r.decision || 'unknown';
+      byModel[m] = (byModel[m] || 0) + 1;
+      byDecision[d] = (byDecision[d] || 0) + 1;
+      if (typeof r.response_time_ms === 'number') {
+        latencySum += r.response_time_ms;
+        latencyN += 1;
+      }
+    }
+
+    res.json({
+      success: true,
+      count: rows.length,
+      stats: {
+        by_model: byModel,
+        by_decision: byDecision,
+        avg_p1_latency_ms: latencyN ? Math.round(latencySum / latencyN) : null,
+      },
+      offers: rows,
+    });
+  } catch (err) {
+    console.error('[admin/offer-monitor] error:', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── POST /api/admin/query ────────────────────────────────────────────────────
+// Arbitrary read-only SELECT, executed under the dedicated read-only role.
+router.post('/query', async (req, res) => {
+  const pool = getReadonlyPool();
+  if (!pool) {
+    return res.status(503).json({
+      error: 'readonly_role_not_configured',
+      message: 'Raw query disabled: set VECTO_READONLY_DATABASE_URL (a SELECT-only role) in deployment secrets. See docs/architecture/PROD_QUERY_BRIDGE.md.',
+    });
+  }
+
+  const raw = typeof req.body?.sql === 'string' ? req.body.sql.trim() : '';
+  if (!raw) {
+    return res.status(400).json({ error: 'missing_sql', message: 'Provide { "sql": "SELECT ..." }' });
+  }
+
+  // Defense-in-depth (the read-only ROLE is the real guard): single statement,
+  // must begin with SELECT or WITH. A trailing ';' is allowed and stripped.
+  const queryText = raw.replace(/;\s*$/, '');
+  if (queryText.includes(';')) {
+    return res.status(400).json({ error: 'single_statement_only', message: 'Only one statement is allowed (no inner ";").' });
+  }
+  if (!/^(select|with)\b/i.test(queryText)) {
+    return res.status(400).json({ error: 'select_only', message: 'Only SELECT / WITH queries are permitted.' });
+  }
+
+  let client;
+  try {
+    client = await pool.connect();
+    await client.query('BEGIN');
+    await client.query('SET TRANSACTION READ ONLY');
+    await client.query(`SET LOCAL statement_timeout = ${STMT_TIMEOUT_MS}`);
+    // Cap rows at the DATABASE level (LIMIT in an outer subquery) so a huge result set
+    // can never be materialized into the app's memory before we slice — prevents OOM.
+    // MAX_ROWS+1 lets us detect truncation.
+    const capped = `SELECT * FROM ( ${queryText} ) AS _bridge_sub LIMIT ${MAX_ROWS + 1}`;
+    const result = await client.query(capped);
+    await client.query('ROLLBACK');
+    const rows = result.rows.slice(0, MAX_ROWS);
+    res.json({
+      success: true,
+      rowCount: result.rowCount,
+      returned: rows.length,
+      truncated: result.rows.length > MAX_ROWS,
+      fields: (result.fields || []).map((f) => f.name),
+      rows,
+    });
+  } catch (err) {
+    // The read-only role rejects writes / non-granted tables → clean error here.
+    if (client) {
+      try { await client.query('ROLLBACK'); } catch { /* already aborted */ }
+    }
+    res.status(400).json({ error: 'query_failed', message: err.message });
+  } finally {
+    if (client) client.release();
+  }
+});
+
+export default router;

--- a/server/api/admin/monitor.js
+++ b/server/api/admin/monitor.js
@@ -20,6 +20,7 @@
 
 import express, { Router } from 'express';
 import pkg from 'pg';
+import rateLimit from 'express-rate-limit';
 import { sql } from 'drizzle-orm';
 import { db } from '../../db/drizzle.js';
 import { offer_intelligence } from '../../../shared/schema.js';
@@ -31,6 +32,22 @@ const router = Router();
 // Auth first (reject unauthenticated before parsing a body), then JSON parsing.
 router.use(requireAgentOnly);
 router.use(express.json({ limit: '64kb' }));
+
+const monitorReadLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'rate_limited', message: 'Too many requests. Please retry shortly.' },
+});
+
+const monitorQueryLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'rate_limited', message: 'Too many query requests. Please retry shortly.' },
+});
 
 const MAX_ROWS = 1000;
 const STMT_TIMEOUT_MS = 10000;
@@ -53,7 +70,7 @@ function getReadonlyPool() {
 
 // ─── GET /api/admin/offer-monitor ─────────────────────────────────────────────
 // Fleet-wide recent offers + aggregate stats. Fixed Drizzle query (no user SQL).
-router.get('/offer-monitor', async (req, res) => {
+router.get('/offer-monitor', monitorReadLimiter, async (req, res) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 50, 500);
     const rows = await db
@@ -107,7 +124,7 @@ router.get('/offer-monitor', async (req, res) => {
 
 // ─── POST /api/admin/query ────────────────────────────────────────────────────
 // Arbitrary read-only SELECT, executed under the dedicated read-only role.
-router.post('/query', async (req, res) => {
+router.post('/query', monitorQueryLimiter, async (req, res) => {
   const pool = getReadonlyPool();
   if (!pool) {
     return res.status(503).json({

--- a/server/api/hooks/analyze-offer.js
+++ b/server/api/hooks/analyze-offer.js
@@ -752,6 +752,8 @@ router.get('/offer-history', async (req, res) => {
         decision: offer_intelligence.decision,
         decision_reasoning: offer_intelligence.decision_reasoning,
         confidence_score: offer_intelligence.confidence_score,
+        ai_model: offer_intelligence.ai_model,        // 2026-06-11: surface the model that decided (telemetry verification)
+        input_mode: offer_intelligence.input_mode,    // 2026-06-11: 'vision' | 'text'
         user_override: offer_intelligence.user_override,
         response_time_ms: offer_intelligence.response_time_ms,
         local_date: offer_intelligence.local_date,

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -121,6 +121,12 @@ export async function mountRoutes(app, server) {
     { path: '/api/hooks', module: './server/api/hooks/analyze-offer.js', desc: 'External Hooks (OCR/Signals)' },
     { path: '/api/hooks', module: './server/api/hooks/translate.js', desc: 'Siri Translation Hook' },
 
+    // 2026-06-11: Admin prod read-only observability bridge (server/api/admin/) — bridge-auth ONLY.
+    // Lets the terminal dev agent monitor prod over HTTPS (prod DB is app-scoped, not
+    // reachable from the dev terminal). Structured /offer-monitor (Drizzle) + raw /query
+    // (dedicated read-only role). See docs/architecture/PROD_QUERY_BRIDGE.md.
+    { path: '/api/admin', module: './server/api/admin/monitor.js', desc: 'Admin prod-query/monitor (bridge-auth, read-only)' },
+
     // 2026-01-09: Removed EventEmitter SSE - DB NOTIFY SSE is canonical (mountSSE)
     // The /events mount was duplicating /events/strategy, /events/blocks with EventEmitter
     // while mountSSE() mounts DB-backed versions at same paths. See LESSONS_LEARNED.md.

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -340,5 +340,20 @@ export async function requireAuthAllowQueryToken(req, res, next) {
   return requireAuth(req, res, next);
 }
 
+// 2026-06-11: Strict agent-ONLY guard for admin/observability routes.
+// Unlike requireAuth (which ALSO accepts valid end-user sessions), this rejects
+// everything except a valid agent/bridge token (x-vecto-agent-secret /
+// x-claude-bridge-token, constant-time compared in validateAgentAuth). Used by the
+// prod read-only query bridge (server/api/admin/monitor.js) so a logged-in end user
+// can never reach the raw-query surface — only a bridge-token holder can.
+export function requireAgentOnly(req, res, next) {
+  const agentAuth = validateAgentAuth(req);
+  if (!agentAuth) {
+    return res.status(401).json({ error: 'agent_auth_required', message: 'This endpoint requires a valid agent/bridge token.' });
+  }
+  req.auth = { userId: agentAuth.userId, isAgent: true, tokenSource: agentAuth.tokenSource };
+  return next();
+}
+
 // Export constants for use in other modules
 export { SYSTEM_AGENT_USER_ID, AGENT_SECRET_HEADER };


### PR DESCRIPTION
## Summary

A **read-only production query bridge** so the terminal dev agent (Claude Code) can monitor and analyze prod data — without a direct DB connection. On current Replit infra the prod DB is **app-scoped** (only the deployed app can reach it), so the agent calls the deployed app over HTTPS and the app queries prod. Closes the recurring "can't see prod from dev" gap (`claude_memory #351`) and the coach-memo access gap (`#352`).

## Endpoints (`/api/admin`, **bridge-auth only**)
- **`GET /offer-monitor`** — fixed Drizzle: recent offers across all devices + aggregate stats (model breakdown, decision rates, avg P1 latency). **Zero user-SQL surface.**
- **`POST /query`** — arbitrary read-only `SELECT`, executed under a **dedicated read-only role** (`VECTO_READONLY_DATABASE_URL`): SELECT-only GRANTs on allowlisted tables, `default_transaction_read_only`, `statement_timeout`, per-txn `READ ONLY`, and a **DB-level** outer-`LIMIT` row cap. **Disabled (503), never the app pool**, if the role isn't configured.
- `GET /offer-history` now returns `ai_model` + `input_mode`.
- `scripts/query-prod.js` — terminal CLI (`--monitor` or raw SELECT, `--out` to JSON).

## Security
- **Auth:** `requireAgentOnly` — strict bridge-token-only (`x-claude-bridge-token` / `x-vecto-agent-secret`, constant-time), no end-user sessions.
- **Capability, not validation:** the raw endpoint's safety is the **read-only role** (can't write, can't read non-allowlisted tables) + timeouts — not a regex.
- **Adversarial review (4 red-team angles): verdict `ship`**, no high/critical. Two mediums fixed in this PR: RO-pool `connectionTimeoutMillis` (no infinite hang) and setup-SQL hardening against `PUBLIC`-granted functions (`NOSUPERUSER` + revoke guidance). Also self-caught + fixed an OOM (row cap now at the DB level, pre-materialization).
- **Residual risk** is operator-dependent: the guarantee rests on running the setup SQL so the role is non-superuser + SELECT-only.

## Activation (after merge)
1. On **prod** (Database tool → Production → SQL runner), run the `CREATE ROLE vecto_readonly …` block in `docs/architecture/PROD_QUERY_BRIDGE.md`.
2. Add `VECTO_READONLY_DATABASE_URL` (the read-only role) to **Deployment** secrets; ensure `CLAUDE_BRIDGE_TOKEN` is in both deployment + workspace.
3. Republish. Then: `node scripts/query-prod.js --monitor`.

## Not included (deliberate)
The coach also proposed a **prod→dev sync** script. Dropped on review — it breaks dev/prod isolation (§7 + Replit docs) and risks driver PII landing in the dev DB. Analyze JSON exports instead. Tracked in `todo #6`.

## Test plan
- [x] `npm run lint` exit 0
- [x] Adversarial security review → `ship`, mediums fixed
- [ ] Post-merge: smoke-test `GET /api/admin/offer-monitor` on prod with the bridge token after the read-only role is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
