### PR TITLE
2026-06-11: location — always require live GPS, no silent fallbacks (fixes 28-mi-off)

### DIFF
--- a/client/src/contexts/location-context-clean.tsx
+++ b/client/src/contexts/location-context-clean.tsx
@@ -82,15 +82,16 @@ function getGeoPosition(): Promise<{ latitude: number; longitude: number; accura
       return;
     }
 
-    // Manual timeout - must be > browser timeout to let browser respond first
-    // Browser timeout is 10s, so manual is 12s as fallback
+    // Manual timeout - must be > browser timeout to let browser respond first.
+    // 2026-06-11: browser GPS timeout raised to 15s (high-accuracy cold start needs room),
+    // so this anti-hang fallback is 17s (> 15s) — otherwise it would preempt a slow GPS fix.
     const manualTimeout = setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        console.warn('[getGeoPosition] Manual timeout (12s) - browser geolocation hung.');
+        console.warn('[getGeoPosition] Manual timeout (17s) - browser geolocation hung.');
         resolve(null);
       }
-    }, 12000);
+    }, 17000);
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -104,44 +105,23 @@ function getGeoPosition(): Promise<{ latitude: number; longitude: number; accura
           accuracy: position.coords.accuracy
         });
       },
-      async (error) => {
+      (error) => {
         if (resolved) return;
-        console.warn('[getGeoPosition] Browser failed:', error.code, error.message);
-
-        // Fallback: Google Geolocation API (works when browser GPS fails)
-        const GOOGLE_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-        if (GOOGLE_API_KEY) {
-          try {
-            console.log('[getGeoPosition] Trying Google Geolocation API fallback...');
-            const res = await fetch(
-              `https://www.googleapis.com/geolocation/v1/geolocate?key=${GOOGLE_API_KEY}`,
-              { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' }
-            );
-            if (res.ok) {
-              const data = await res.json();
-              if (data?.location) {
-                resolved = true;
-                clearTimeout(manualTimeout);
-                console.log('[getGeoPosition] Google API success:', data.location.lat, data.location.lng);
-                resolve({
-                  latitude: data.location.lat,
-                  longitude: data.location.lng,
-                  accuracy: data.accuracy || 100
-                });
-                return;
-              }
-            }
-          } catch (e) {
-            console.warn('[getGeoPosition] Google API fallback failed:', e);
-          }
-        }
-
-        // No fallback worked
+        // 2026-06-11: NO FALLBACK — fail hard (per Melody + CLAUDE.md "fail hard on missing GPS").
+        // The previous Wi-Fi/IP geolocate fallback returned COARSE coords (false 6-decimal
+        // precision) that silently corrupted the whole GPS-derived pipeline (city, timezone,
+        // coords_key, venue ranking). Returning null makes the caller raise a CriticalError that
+        // prompts the driver to enable precise Location Services — a wrong location is worse than none.
         resolved = true;
         clearTimeout(manualTimeout);
+        console.error('[getGeoPosition] GPS unavailable (no fallback by design):', error.code, error.message);
         resolve(null);
       },
-      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 }
+      // 2026-06-11: ALWAYS request a fresh GPS fix. enableHighAccuracy:false previously let
+      // Safari position by Wi-Fi/IP (~28 mi off) and maximumAge:60000 accepted a 60s-stale cache.
+      // The entire pipeline (city → timezone → venue ranking) keys off this coordinate, so
+      // accuracy here is non-negotiable. (PublicConciergePage already uses highAccuracy:true.)
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 }
     );
   });
 }
@@ -752,15 +732,14 @@ export const LocationProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         // Driver may be at same coords but needs fresh snapshot data every sign-in.
         // The dedup check only applies to the auto-enrich effect (coord change detection).
         await enrichLocation(coords.latitude, coords.longitude, coords.accuracy, true);
-      } else if (profile?.homeLat && profile?.homeLng) {
-        // Fallback to home location from user's profile (set during registration)
-        console.log('🏠 [LocationContext] GPS unavailable - using home location from profile');
-        setCurrentCoords({ latitude: profile.homeLat, longitude: profile.homeLng });
-        await enrichLocation(profile.homeLat, profile.homeLng, 100, true);
       } else {
-        // No GPS and no home location - user needs to enable GPS
-        console.warn('[LocationContext] No GPS and no home location - cannot proceed');
-        setCurrentLocationString('Location unavailable - enable GPS');
+        // 2026-06-11: NO FALLBACK — fail hard. This previously fell back to profile.homeLat/homeLng,
+        // silently substituting the driver's REGISTERED HOME for their LIVE location (often tens of
+        // miles off) — and because that path never calls the Geolocation API, Safari never prompts.
+        // Location MUST come from live GPS, never the profile (memory #213 / #231 / #332). Surface a
+        // CriticalError so the driver enables precise Location Services and retries.
+        console.error('[LocationContext] GPS unavailable — failing hard (no profile/home fallback)');
+        setLocationError({ code: 'gps_unavailable', message: 'Location Services are off or blocked. Enable precise location for Safari, then retry.' });
       }
     } finally {
       setIsUpdating(false);


### PR DESCRIPTION
## Summary

Fixes "location is ~28 miles off" (reported while physically *at* the registered home base, in Safari). Root cause: **the app wasn't actually requiring live GPS.** A low-accuracy request plus two silent fallbacks meant the snapshot coordinate everything keys off (city, timezone, 6-decimal `coords_key`, venue ranking) could resolve to a coarse Wi-Fi/IP point at the ISP's hub — with no Safari permission prompt to signal it.

## Changes (`client/src/contexts/location-context-clean.tsx`)
- **`enableHighAccuracy: false → true`, `maximumAge: 60000 → 0`, `timeout: 10s → 15s`** — the actual fix. Safari had permission already granted (so no re-prompt on log-out/in) and was silently returning a Wi-Fi/IP fix ~28 mi away. Now: always a fresh GPS fix.
- **Manual anti-hang timeout `12s → 17s`** — so it can't preempt a slow high-accuracy fix (must stay > the 15s browser timeout).
- **Removed the Wi-Fi/IP `geolocate` fallback** → coarse coords are false 6-decimal precision; fail hard (`null`).
- **Removed the `profile.homeLat/homeLng` fallback** → it silently used the driver's *registered home* for their *live* location and never engaged the Geolocation API (so Safari never prompted). Now fails hard via `setLocationError` → `CriticalError` prompting Location Services. Location comes from GPS, never the profile (memory #213 / #231 / #332).

## Test plan
- [x] `npm run typecheck` (`tsc -b`) exit 0
- [x] `npm run lint` exit 0 on the file
- [ ] **Real-device Safari test post-deploy**: at a known location, confirm the app prompts for / uses precise GPS and resolves the correct city; with Location Services off, confirm it raises CriticalError (not a silent wrong location).

## Follow-ups (noted, not in this PR)
- **Dormant `GET /api/location/ip`** (IP geolocation via ip-api.com, `location.js:2095`) — no client caller today ("for previews/iframes"), but it's a coarse-location source; recommend removing or gating per the no-fallback doctrine.
- `PublicConciergePage.tsx:86` (kiosk, separate path) still uses `maximumAge: 60000` — fine for the rider kiosk, flagged for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
