### PR TITLE
Offer Analyzer: fare validation + ARP Trip Radar gate + venue address-resolution coalescing

### DIFF
--- a/client/src/components/offer-analyzer/OffersCard.tsx
+++ b/client/src/components/offer-analyzer/OffersCard.tsx
@@ -1,9 +1,13 @@
 // client/src/components/offer-analyzer/OffersCard.tsx
 // 2026-07-03 (todo #10): Live offer history + outcome capture (design §7-§8).
-// Shows the analyzer's recommendation per offer ("our call") and lets the driver
-// record what actually happened ("your call") — the disagreements feed the coach.
-// Refetches on the offer_analyzed SSE event; earnings unlock on Accepted/Completed.
-// Row shape is the FLAT offer_intelligence LEFT JOIN offer_outcomes row that
+// 2026-08-24: Upfront-fare validation (Earnings Log Module). Accepted offers
+// settle through a panel that assumes the payout equals the accepted upfront
+// fare (fare pre-filled and locked); tips/tolls/extras go on top, and "Paid
+// different than what I accepted" unlocks the fare and records a mismatch —
+// the per-offer test that the platform honors its upfront fares. Saving stamps
+// settled_at and the offer leaves the queue (Show settled reveals history).
+// Refetches on the offer_analyzed SSE event. Row shape is the FLAT
+// offer_intelligence LEFT JOIN offer_outcomes row that
 // GET /api/offer-analyzer/offers returns (server/api/offer-analyzer/index.js).
 
 import { useEffect, useMemo, useState } from 'react';
@@ -45,6 +49,13 @@ interface AnalyzedOffer {
   extras?: number | null;
   other?: number | null;
   total_earned?: number | null;
+  // Upfront-fare validation (2026-08-24)
+  tips?: number | null;
+  tolls?: number | null;
+  upfront_price?: number | null;
+  fare_matched_upfront?: boolean | null;
+  settled_at?: string | null;
+  total_realized?: number | null; // total_earned + tips + tolls (computed server-side)
 }
 
 // Mirrors GET /api/offer-analyzer/offers stats (server/api/offer-analyzer/index.js).
@@ -55,6 +66,8 @@ interface OffersStats {
   driver_accepted?: number;
   disagreements?: number;
   realized_total?: number;
+  fares_validated?: number;
+  fare_mismatches?: number;
 }
 
 interface OffersResponse {
@@ -89,10 +102,8 @@ function decisionBadgeClass(decision: string): string {
 }
 
 // 2026-07-03 review fix: "Followed the call" used to store NULL, which conflated
-// "unrecorded" with "followed", blocked earnings capture for followed ACCEPTs,
-// and excluded the most common outcome from every stat. It now resolves to the
-// concrete decision implied by our recommendation (ACCEPT→Accepted, REJECT→Rejected);
-// unrecorded offers show a placeholder instead of a pre-selected answer.
+// "unrecorded" with "followed" — it now resolves to the concrete decision implied
+// by our recommendation (ACCEPT→Accepted, REJECT→Rejected).
 const DECISION_OPTIONS = [
   { value: 'followed', label: 'Followed the call' },
   { value: 'Accepted', label: 'Accepted' },
@@ -101,24 +112,35 @@ const DECISION_OPTIONS = [
   { value: 'Completed', label: 'Completed' },
 ] as const;
 
-const EARNINGS_FIELDS = [
-  { key: 'actual_pay', label: 'Actual pay' },
-  { key: 'reimbursements', label: 'Reimbursements' },
+// Earnings Log Module fields (product spec §3, Offer Analyzer tab): baseline
+// fare + tips + toll reimbursements + extras. Fare is handled separately (it is
+// the upfront-price validation target); these three stack on top of it.
+const ADDON_FIELDS = [
+  { key: 'tips', label: 'Tips' },
+  { key: 'tolls', label: 'Tolls' },
   { key: 'extras', label: 'Extras' },
-  { key: 'other', label: 'Other' },
 ] as const;
 
-type EarningsKey = (typeof EARNINGS_FIELDS)[number]['key'];
-type EarningsDraft = Record<EarningsKey, string>;
+type AddonKey = (typeof ADDON_FIELDS)[number]['key'];
 
-function draftFromOffer(offer: AnalyzedOffer): EarningsDraft {
+interface SettleDraft extends Record<AddonKey, string> {
+  fare: string;
+}
+
+function draftFromOffer(offer: AnalyzedOffer): SettleDraft {
   const s = (v: number | null | undefined) => (v != null ? String(v) : '');
+  // Default assumption: the payout equals the accepted upfront fare.
+  const fare = toNum(offer.actual_pay) ?? toNum(offer.price);
   return {
-    actual_pay: s(toNum(offer.actual_pay)),
-    reimbursements: s(toNum(offer.reimbursements)),
+    fare: s(fare),
+    tips: s(toNum(offer.tips)),
+    tolls: s(toNum(offer.tolls)),
     extras: s(toNum(offer.extras)),
-    other: s(toNum(offer.other)),
   };
+}
+
+function fmtMoney(v: number | null | undefined): string {
+  return v != null ? `$${v.toFixed(2)}` : '—';
 }
 
 interface OfferRowProps {
@@ -129,18 +151,23 @@ interface OfferRowProps {
 function OfferRow({ offer, onOutcomeSaved }: OfferRowProps) {
   const { toast } = useToast();
   const [isPosting, setIsPosting] = useState(false);
-  const [draft, setDraft] = useState<EarningsDraft>(() => draftFromOffer(offer));
+  const [draft, setDraft] = useState<SettleDraft>(() => draftFromOffer(offer));
+  const [fareDiffers, setFareDiffers] = useState(offer.fare_matched_upfront === false);
 
   const driverDecision = offer.driver_decision ?? null;
   // No outcome recorded → placeholder, never a pre-selected answer.
   const selectValue = driverDecision ?? '';
-  const showEarnings = driverDecision === 'Accepted' || driverDecision === 'Completed';
+  const isTaken = driverDecision === 'Accepted' || driverDecision === 'Completed';
+  const isSettled = offer.settled_at != null;
+  const upfrontPrice = toNum(offer.price);
+  const showSettlePanel = isTaken && !isSettled;
 
-  // Re-sync the earnings draft when a refetch brings back the saved outcome.
+  // Re-sync the draft when a refetch brings back the saved outcome.
   useEffect(() => {
-    // Keyed to the joined outcome values, not the whole row object identity.
     setDraft(draftFromOffer(offer));
-  }, [offer.outcome_id, offer.actual_pay, offer.reimbursements, offer.extras, offer.other]);
+    setFareDiffers(offer.fare_matched_upfront === false);
+    // Keyed to the joined outcome values, not the whole row object identity.
+  }, [offer.outcome_id, offer.actual_pay, offer.tips, offer.tolls, offer.extras, offer.fare_matched_upfront, offer.settled_at]);
 
   const postOutcome = async (body: Record<string, unknown>, successTitle: string) => {
     setIsPosting(true);
@@ -170,49 +197,62 @@ function OfferRow({ offer, onOutcomeSaved }: OfferRowProps) {
     const resolved = value === 'followed'
       ? (offer.decision === 'ACCEPT' ? 'Accepted' : 'Rejected')
       : value;
-    // The upsert overwrites every column. Earnings carry over only between the
-    // taken states (Accepted ↔ Completed); switching to Rejected/Cancelled
-    // clears them — otherwise the realized total stays inflated with dollars
-    // from a ride that didn't happen, with no UI path to remove them.
-    const keepEarnings = resolved === 'Accepted' || resolved === 'Completed';
+    const taken = resolved === 'Accepted' || resolved === 'Completed';
+    // Rejected/Cancelled have nothing to validate — they settle (and leave the
+    // queue) immediately, with earnings cleared so no phantom dollars linger.
+    // Accepted/Completed stay OPEN: the fare-validation panel must be saved
+    // before the offer settles, so picking a decision never skips the fare test.
     postOutcome(
       {
         driver_decision: resolved,
-        actual_pay: keepEarnings ? toNum(offer.actual_pay) : null,
-        reimbursements: keepEarnings ? toNum(offer.reimbursements) : null,
-        extras: keepEarnings ? toNum(offer.extras) : null,
-        other: keepEarnings ? toNum(offer.other) : null,
+        actual_pay: taken ? toNum(offer.actual_pay) : null,
+        tips: taken ? toNum(offer.tips) : null,
+        tolls: taken ? toNum(offer.tolls) : null,
+        extras: taken ? toNum(offer.extras) : null,
+        reimbursements: taken ? toNum(offer.reimbursements) : null,
+        other: taken ? toNum(offer.other) : null,
+        upfront_price: taken ? toNum(offer.upfront_price) : null,
+        fare_matched_upfront: taken ? offer.fare_matched_upfront ?? null : null,
+        settled: !taken,
       },
-      'Outcome recorded'
+      taken ? 'Marked as taken — confirm the fare below' : 'Outcome recorded'
     );
   };
 
-  const draftTotal = EARNINGS_FIELDS.reduce((sum, f) => {
-    const n = Number(draft[f.key]);
-    return sum + (draft[f.key] !== '' && Number.isFinite(n) ? n : 0);
-  }, 0);
+  const numeric = (v: string): number | null => {
+    if (v === '') return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
 
-  const saveEarnings = () => {
-    const numeric = (v: string): number | null => {
-      if (v === '') return null;
-      const n = Number(v);
-      return Number.isFinite(n) ? n : null;
-    };
+  const fareValue = fareDiffers || upfrontPrice == null ? numeric(draft.fare) : upfrontPrice;
+  const draftTotal = (fareValue ?? 0)
+    + ADDON_FIELDS.reduce((sum, f) => sum + (numeric(draft[f.key]) ?? 0), 0);
+
+  const saveSettlement = () => {
+    // The whole point of the upfront test: unless the driver flags a difference,
+    // the fare saved IS the accepted upfront price — copied exactly, never typed.
     postOutcome(
       {
         driver_decision: driverDecision,
-        actual_pay: numeric(draft.actual_pay),
-        reimbursements: numeric(draft.reimbursements),
+        actual_pay: fareValue,
+        tips: numeric(draft.tips),
+        tolls: numeric(draft.tolls),
         extras: numeric(draft.extras),
-        other: numeric(draft.other),
+        reimbursements: toNum(offer.reimbursements),
+        other: toNum(offer.other),
+        upfront_price: upfrontPrice,
+        fare_matched_upfront: upfrontPrice != null ? !fareDiffers : null,
+        settled: true,
       },
-      'Earnings saved'
+      'Offer settled'
     );
   };
 
   const perMile = toNum(offer.per_mile);
   const totalMiles = toNum(offer.total_miles);
   const price = toNum(offer.price);
+  const totalRealized = toNum(offer.total_realized) ?? toNum(offer.total_earned);
 
   return (
     <div className="rounded-lg border border-gray-200 p-3 space-y-3">
@@ -252,11 +292,48 @@ function OfferRow({ offer, onOutcomeSaved }: OfferRowProps) {
         </Select>
       </div>
 
-      {showEarnings && (
+      {showSettlePanel && (
         <div className="rounded-lg bg-gray-50 border border-gray-200 p-3 space-y-2">
-          <span className="text-xs font-medium text-gray-600">What did it pay?</span>
-          <div className="grid grid-cols-2 gap-2">
-            {EARNINGS_FIELDS.map((f) => (
+          <span className="text-xs font-medium text-gray-600">
+            {upfrontPrice != null ? 'Confirm what it paid' : 'What did it pay?'}
+          </span>
+
+          <div className="space-y-1">
+            <label className="text-xs text-gray-500">
+              {upfrontPrice != null ? 'Fare — as accepted' : 'Fare'}
+            </label>
+            <Input
+              type="number"
+              inputMode="decimal"
+              step="0.01"
+              min="0"
+              placeholder="0.00"
+              value={fareDiffers || upfrontPrice == null ? draft.fare : String(upfrontPrice)}
+              disabled={upfrontPrice != null && !fareDiffers}
+              onChange={(e) => setDraft({ ...draft, fare: e.target.value })}
+              className="bg-white border-gray-300 text-gray-900 disabled:bg-gray-100 disabled:text-gray-500"
+            />
+          </div>
+
+          {upfrontPrice != null && (
+            <label className="flex items-center gap-2 text-xs text-gray-600">
+              <input
+                type="checkbox"
+                checked={fareDiffers}
+                onChange={(e) => {
+                  setFareDiffers(e.target.checked);
+                  // Unchecking snaps the fare back to the accepted upfront price.
+                  setDraft({ ...draft, fare: String(upfrontPrice) });
+                }}
+                className="h-4 w-4 rounded border-gray-300"
+                disabled={isPosting}
+              />
+              Paid different than what I accepted
+            </label>
+          )}
+
+          <div className="grid grid-cols-3 gap-2">
+            {ADDON_FIELDS.map((f) => (
               <div key={f.key} className="space-y-1">
                 <label className="text-xs text-gray-500">{f.label}</label>
                 <Input
@@ -272,15 +349,34 @@ function OfferRow({ offer, onOutcomeSaved }: OfferRowProps) {
               </div>
             ))}
           </div>
+
           <div className="flex items-center justify-between pt-1">
             <span className="text-sm text-gray-600">
               Total: <span className="font-semibold text-gray-900 tabular-nums">${draftTotal.toFixed(2)}</span>
             </span>
-            <Button type="button" size="sm" onClick={saveEarnings} disabled={isPosting}>
+            <Button type="button" size="sm" onClick={saveSettlement} disabled={isPosting}>
               {isPosting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Save
             </Button>
           </div>
+        </div>
+      )}
+
+      {isSettled && (
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          {isTaken && (
+            <span className="text-gray-600">
+              Earned <span className="font-semibold text-gray-900 tabular-nums">{fmtMoney(totalRealized)}</span>
+            </span>
+          )}
+          {offer.fare_matched_upfront === true && (
+            <Badge className="bg-emerald-100 text-emerald-800 border-transparent">Fare matched</Badge>
+          )}
+          {offer.fare_matched_upfront === false && (
+            <Badge className="bg-amber-100 text-amber-800 border-transparent">
+              Paid {fmtMoney(toNum(offer.actual_pay))} vs {fmtMoney(toNum(offer.upfront_price))} accepted
+            </Badge>
+          )}
         </div>
       )}
     </div>
@@ -289,6 +385,7 @@ function OfferRow({ offer, onOutcomeSaved }: OfferRowProps) {
 
 export default function OffersCard() {
   const queryClient = useQueryClient();
+  const [showSettled, setShowSettled] = useState(false);
   const offersQueryKey = useMemo(() => QUERY_KEYS.OFFER_ANALYZER_OFFERS(OFFERS_LIMIT), []);
   const { data, isLoading, error, refetch } = useQuery<OffersResponse>({
     queryKey: offersQueryKey,
@@ -333,6 +430,12 @@ export default function OffersCard() {
   const offers = data?.offers ?? [];
   const stats = data?.stats;
 
+  // The queue: settled offers leave the list ("once the user saves the offer
+  // goes away" — Melody). Show settled reveals the history for recovery.
+  const pendingOffers = offers.filter((o) => o.settled_at == null);
+  const settledOffers = offers.filter((o) => o.settled_at != null);
+  const visibleOffers = showSettled ? offers : pendingOffers;
+
   const tiles = [
     {
       label: 'Analyzed',
@@ -357,11 +460,17 @@ export default function OffersCard() {
     },
     {
       label: 'Realized',
-      value: `$${(stats?.realized_total ?? offers.reduce((s, o) => s + (toNum(o.total_earned) ?? 0), 0)).toFixed(2)}`,
+      value: `$${(
+        stats?.realized_total ??
+        offers.reduce((s, o) => s + (toNum(o.total_realized) ?? toNum(o.total_earned) ?? 0), 0)
+      ).toFixed(2)}`,
       caption: 'Your call',
       captionClass: 'text-emerald-600',
     },
   ];
+
+  const faresValidated = stats?.fares_validated ?? 0;
+  const fareMismatches = stats?.fare_mismatches ?? 0;
 
   return (
     <Card className="bg-white border-gray-200 shadow-sm">
@@ -400,16 +509,46 @@ export default function OffersCard() {
               ))}
             </div>
 
+            {faresValidated > 0 && (
+              <p className="text-xs text-gray-500">
+                Upfront fares checked: <span className="font-semibold text-gray-700">{faresValidated}</span>
+                {' · '}mismatches:{' '}
+                <span className={`font-semibold ${fareMismatches > 0 ? 'text-amber-600' : 'text-gray-700'}`}>
+                  {fareMismatches}
+                </span>
+              </p>
+            )}
+
             {offers.length === 0 ? (
               <p className="text-sm text-gray-400 italic">
                 No offers yet — run the Shortcut on your next ping and it will show up here.
               </p>
             ) : (
-              <div className="space-y-3">
-                {offers.map((offer) => (
-                  <OfferRow key={offer.id} offer={offer} onOutcomeSaved={() => refetch()} />
-                ))}
-              </div>
+              <>
+                {visibleOffers.length === 0 ? (
+                  <p className="text-sm text-gray-400 italic">
+                    All caught up — settled offers are under Show settled.
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {visibleOffers.map((offer) => (
+                      <OfferRow key={offer.id} offer={offer} onOutcomeSaved={() => refetch()} />
+                    ))}
+                  </div>
+                )}
+
+                {settledOffers.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-gray-500"
+                    onClick={() => setShowSettled((v) => !v)}
+                  >
+                    {showSettled ? 'Hide settled' : `Show settled (${settledOffers.length})`}
+                  </Button>
+                )}
+              </>
             )}
           </>
         )}

--- a/client/src/contexts/co-pilot-context.tsx
+++ b/client/src/contexts/co-pilot-context.tsx
@@ -688,6 +688,14 @@ export function CoPilotProvider({ children }: { children: React.ReactNode }) {
       if (error?.code === 'RANKING_ID_MISSING') return false;
       return failureCount < 6;
     },
+    // 2026-08-26 (Melody's #2): a READY blocks response was refetched on every
+    // window focus/remount (default staleTime 0), and each ready GET re-enters
+    // venue address resolution server-side. Mirror the strategy query's cache
+    // windows — the SSE blocks_ready handler and manual refetchBlocks() use
+    // refetchQueries/refetch, which bypass staleTime, so freshness pushes
+    // still land immediately.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 
   // 2026-01-15: FAIL HARD - Detect blocks errors and trigger critical error

--- a/docs/architecture/OFFER_ANALYZER.md
+++ b/docs/architecture/OFFER_ANALYZER.md
@@ -382,10 +382,23 @@ pickup_limits exceeded     → REJECT 'pickup'          (never rescued)
 time_limit exceeded && !unless-conjunction    → REJECT 'time_limit' (never rescued)
 miles > tier max_total_miles (v3.1)           → REJECT 'too_far'
 accept ladder, first match                    → ACCEPT 'accept'
-[ARP enabled] per_mile >= min_per_total_mile  → ACCEPT 'accept_fallback' (fallback:true)
+[ARP enabled] per_mile >= min_per_total_mile
+              && is_exclusive !== false       → ACCEPT 'accept_fallback' (fallback:true)
 [ARP enabled] deferred floor misses           → REJECT 'floor' | 'min_floor'
 minutes > 40                                  → REJECT 'too_far'
 else                                          → REJECT 'low'
+
+ARP × exclusivity (2026-08-25, Melody): the fallback exists only to protect
+acceptance rate, and only declining an EXCLUSIVE offer hurts AR — a Trip Radar
+offer ("Match" button, no Exclusive badge) costs nothing to decline. `is_exclusive`
+is a first-class flag: text lane = `/\bexclusive\b/i` over the raw text
+(parse-offer-text.js — the chip renders separately from the product on
+Comfort/Priority cards, where extractProductType drops it); vision lane = model
+boolean (`"is_exclusive"` joins the JSON template whenever ARP is enabled), with
+"Exclusive" in the product string as positive-evidence fallback. Positively
+non-exclusive (false) blocks the rescue → deferred floor rejects fire; unknown
+(null — legacy rows) preserves it. Rendered into all three prompts + gated in
+`evaluateDeterministic`; pinned in tests/offers/rules-engine-v3.test.js.
 ```
 
 ARP semantics are the spec's: it rescues **profitability** failures only — floors defer

--- a/docs/architecture/OFFER_ANALYZER.md
+++ b/docs/architecture/OFFER_ANALYZER.md
@@ -100,7 +100,10 @@ iPhone Shortcut / Android automation                    (docs: SIRI_/ANDROID_SHO
 
 Web page /co-pilot/offer-analyzer  (authed, /api/offer-analyzer/*)
   SetupCard (token mint/rotate/label) · rules cards (typed forms → PUT /rules, Zod gate)
-  OffersCard (my offers + "what I actually did" + earnings → offer_outcomes)
+  OffersCard (my offers + "what I actually did" + Earnings Log settlement:
+              fare locked to the accepted upfront price + tips/tolls/extras;
+              "Paid different than what I accepted" records a fare mismatch;
+              Save stamps settled_at and the offer leaves the queue → offer_outcomes)
 ```
 
 ---
@@ -770,6 +773,14 @@ uuid → offer_intelligence(id) ON DELETE SET NULL`, `driver_decision text` (CHE
 `Accepted|Rejected|Cancelled|Completed` in the migration), `driver_reasoning`,
 `actual_pay`, `reimbursements`, `extras`, `other`, `total_earned` **GENERATED ALWAYS AS**
 sum **STORED**, `outcome_source text NOT NULL default 'web_app'`, timestamps.
+Fare validation (2026-08-24, `migrations/20260824_offer_outcomes_fare_validation.sql`):
+`tips`, `tolls`, `upfront_price` (snapshot of `offer_intelligence.price` at validation —
+survives the SET NULL FK), `fare_matched_upfront boolean` (NULL until validated; TRUE =
+payout matched the accepted upfront fare; FALSE = differed, actual in `actual_pay`),
+`settled_at timestamptz` (NULL = still open in the Recent Offers queue). `tips`/`tolls`
+sit **outside** the generated `total_earned` (altering a generated column isn't additive);
+readers compute the grand total as `COALESCE(total_earned,0)+COALESCE(tips,0)+COALESCE(tolls,0)`
+(GET /offers `total_realized`; `getOfferPatterns` in `rideshare-coach-dal.js`).
 Indexes: `uq_outcome_offer` (unique partial on `offer_intelligence_id`),
 `idx_outcome_user_created`, `idx_outcome_decision`.
 Drizzle-vs-DB drift (live-checked): the `driver_decision` CHECK and the partial index
@@ -803,8 +814,8 @@ executors (todo #38) — the analyzer never writes it.
 | GET | `/shortcut-token` | get-or-create → `{ token, created_at, device_label }` (404 if no driver profile). Mint writes only into a still-NULL slot (`… AND shortcut_token IS NULL RETURNING`); a raced second request returns the winner's token instead of overwriting it (2026-08-17). |
 | POST | `/shortcut-token/regenerate` | rotate → `{ token, created_at }`; old token dead immediately |
 | POST | `/shortcut-token/label` `{ label }` | ≤80 chars, display only → `{ success, device_label }` |
-| GET | `/offers?limit=25` (≤100) | my `offer_intelligence` LEFT JOIN `offer_outcomes` → `{ success, stats:{ analyzed, analyzer_accepted, analyzer_rejected, driver_accepted, disagreements, realized_total }, offers:[…] }` |
-| POST | `/offers/:id/outcome` `{ driver_decision?, driver_reasoning?, actual_pay?, reimbursements?, extras?, other? }` | 400 on bad enum / non-finite / <0 / >10000; 404 unless the offer is mine; upsert on `offer_intelligence_id` → `{ success, outcome:{ id, driver_decision, total_earned } }` |
+| GET | `/offers?limit=25` (≤100) | my `offer_intelligence` LEFT JOIN `offer_outcomes` → `{ success, stats:{ analyzed, analyzer_accepted, analyzer_rejected, driver_accepted, disagreements, realized_total, fares_validated, fare_mismatches }, offers:[…] }`; rows include `tips, tolls, upfront_price, fare_matched_upfront, settled_at` and computed `total_realized` (= `total_earned`+`tips`+`tolls`); `realized_total` sums `total_realized` over taken rows |
+| POST | `/offers/:id/outcome` `{ driver_decision?, driver_reasoning?, actual_pay?, reimbursements?, extras?, other?, tips?, tolls?, upfront_price?, fare_matched_upfront?, settled? }` | 400 on bad enum / non-finite / <0 / >10000 / non-boolean `fare_matched_upfront`/`settled`; 404 unless the offer is mine; upsert on `offer_intelligence_id` (`settled:true` → `settled_at=NOW()`, else NULL) → `{ success, outcome:{ id, driver_decision, total_earned, tips, tolls, fare_matched_upfront, settled_at } }` |
 | GET | `/places/search?q=` (≥3 chars) | Google Places Text Search (New), 5 results, biased 50 km around `driver_profiles.home_lat/lng`; per-user 20/min (429); 503 without `GOOGLE_MAPS_API_KEY`; → `{ success, results:[{ place_id, label, formatted_address, lat, lng (6-dec), types }] }` |
 
 ---
@@ -824,7 +835,7 @@ Route `client/src/routes.tsx:196` (under `/co-pilot`, ProtectedRoute); hamburger
 | `LimitsCard` | `global.pickup_limits`, `global.time_limit` (+ ARP threshold) |
 | `GeographyCard` | `avoid[]` via `GET /places/search` → place pick → mode / radius / corridor / enable |
 | `VisionRulesCard` | `global.safety_road_types`, `global.commercial_staging`, `global.notices` |
-| `OffersCard` | `GET /offers`, live refetch on SSE `offer_analyzed` **and** on the server's `state` handshake at every SSE (re)connect (skipped when the newest id is already shown; `refetch({ cancelRefetch:false })` joins an in-flight fetch), `refetchOnWindowFocus:true` (was `false` — the tab is backgrounded while the Shortcut runs from the Uber app), per-offer "What did you do?" select (never pre-selected; a *Followed the call* option resolves to our recommendation at click time) + earnings form (shown for Accepted/Completed; cleared when switching to Rejected/Cancelled) → `POST /offers/:id/outcome`; stats row |
+| `OffersCard` | `GET /offers`, live refetch on SSE `offer_analyzed` **and** on the server's `state` handshake at every SSE (re)connect (skipped when the newest id is already shown; `refetch({ cancelRefetch:false })` joins an in-flight fetch), `refetchOnWindowFocus:true` (was `false` — the tab is backgrounded while the Shortcut runs from the Uber app), per-offer "What did you do?" select (never pre-selected; a *Followed the call* option resolves to our recommendation at click time). **Settlement flow (2026-08-24)**: Rejected/Cancelled settle on selection (`settled:true`, earnings cleared); Accepted/Completed open the Earnings Log panel — fare pre-filled with the accepted upfront `price` and **locked**, *"Paid different than what I accepted"* unlocks it (→ `fare_matched_upfront:false`), plus Tips/Tolls/Extras; Save posts `settled:true` and the row leaves the default list (queue = unsettled rows; *Show settled* reveals history with a Fare-matched / Paid-$X-vs-$Y badge; changing a settled row's decision to a taken state re-opens it). Legacy `reimbursements`/`other` inputs removed from the UI; columns remain and still count in totals → `POST /offers/:id/outcome`; stats tiles + "Upfront fares checked · mismatches" line |
 
 Rules save is an explicit sticky **Save** (react-hook-form + Zod), not autosave. The PUT
 carries `expected_version` (what the page loaded); a **409** loads the stored rules from

--- a/migrations/20260824_offer_outcomes_fare_validation.sql
+++ b/migrations/20260824_offer_outcomes_fare_validation.sql
@@ -1,0 +1,34 @@
+-- migrations/20260824_offer_outcomes_fare_validation.sql
+-- Upfront-fare validation on settled offers (Earnings Log Module, spec §3 Offer
+-- Analyzer tab): when the driver records an Accepted offer, the payout is assumed
+-- to equal the accepted upfront fare (actual_pay pre-filled and locked in the UI);
+-- tips and tolls are added on top, and an explicit "paid different than accepted"
+-- path records a fare mismatch — a per-offer test of whether the platform honors
+-- its upfront fares. Saving settles the outcome and removes the offer from the
+-- Recent Offers queue.
+--
+-- Additive only (no drops/alters of existing columns). total_earned (GENERATED
+-- STORED over actual_pay/reimbursements/extras/other) is deliberately untouched:
+-- the grand total including tips+tolls is computed at read time
+-- (COALESCE(total_earned,0)+COALESCE(tips,0)+COALESCE(tolls,0)) in
+-- server/api/offer-analyzer/index.js and rideshare-coach-dal.js getOfferPatterns.
+
+ALTER TABLE offer_outcomes ADD COLUMN IF NOT EXISTS tips double precision;
+ALTER TABLE offer_outcomes ADD COLUMN IF NOT EXISTS tolls double precision;
+
+-- Snapshot of offer_intelligence.price at validation time. The FK is ON DELETE
+-- SET NULL, so the mismatch evidence must survive offer-row deletion on its own.
+ALTER TABLE offer_outcomes ADD COLUMN IF NOT EXISTS upfront_price double precision;
+
+ALTER TABLE offer_outcomes ADD COLUMN IF NOT EXISTS fare_matched_upfront boolean;
+
+-- NULL = outcome still open in the Recent Offers queue; set when the driver
+-- settles (Rejected/Cancelled settle on selection; Accepted/Completed settle when
+-- the fare validation is saved).
+ALTER TABLE offer_outcomes ADD COLUMN IF NOT EXISTS settled_at timestamptz;
+
+COMMENT ON COLUMN offer_outcomes.fare_matched_upfront IS
+  'Upfront-fare honesty test: NULL until validated; TRUE = payout matched the accepted upfront fare (actual_pay copied from upfront_price); FALSE = differed (actual_pay is the driver-entered real payout, upfront_price what was accepted)';
+
+COMMENT ON COLUMN offer_outcomes.settled_at IS
+  'NULL while the offer is still open in the Recent Offers queue; stamped when the driver settles the outcome (UI then hides the row)';

--- a/server/api/hooks/analyze-offer.js
+++ b/server/api/hooks/analyze-offer.js
@@ -603,6 +603,13 @@ router.post('/analyze-offer', upload.single('image'), offerHookLimiter, async (r
         pickup_miles: n(phase1Result.pickup_miles),
         pickup_minutes: n(phase1Result.pickup_minutes),
         rating: (() => { const r = n(phase1Result.rating ?? phase1Result.rider_rating); return r > 0 ? r : null; })(), // 0 = not shown
+        // 2026-08-25 (Melody): gates the ARP fallback — declining a Trip Radar
+        // ("Match", no Exclusive badge) never affects AR, so it is never rescued.
+        // Model boolean wins; else "Exclusive" in the product string is positive
+        // evidence; else unknown (null) — unknown preserves the rescue.
+        is_exclusive: typeof phase1Result.is_exclusive === 'boolean'
+          ? phase1Result.is_exclusive
+          : (/\bexclusive\b/i.test(String(phase1Result.product_type || phase1Result.product || '')) ? true : null),
       };
       const judgment = typeof phase1Result.judgment_reject === 'string' ? phase1Result.judgment_reject.trim() : '';
       // Only arbitrate when the model actually extracted price + miles (else NO DATA territory).
@@ -844,6 +851,9 @@ PRE-PARSED DATA (server-verified):
           // Phase-2's independent verdict — training signal, never the record.
           deep_decision: deepResult?.decision ?? null,
           deep_disagrees: deepDisagrees,
+          // 2026-08-25: exclusivity flag (gates the ARP fallback). Vision lane's
+          // model boolean wins; text lane arrives via the preParsed spread above.
+          ...(typeof phase1Result?.is_exclusive === 'boolean' ? { is_exclusive: phase1Result.is_exclusive } : {}),
         };
 
         // 2026-02-17: Compute geographic columns

--- a/server/api/offer-analyzer/index.js
+++ b/server/api/offer-analyzer/index.js
@@ -218,7 +218,9 @@ router.get('/offers', async (req, res) => {
              oi.confidence_score, oi.input_mode, oi.user_override, oi.response_time_ms,
              oi.ruleset_version, oi.ruleset_hash, oi.created_at,
              oo.id AS outcome_id, oo.driver_decision, oo.driver_reasoning,
-             oo.actual_pay, oo.reimbursements, oo.extras, oo.other, oo.total_earned
+             oo.actual_pay, oo.reimbursements, oo.extras, oo.other, oo.total_earned,
+             oo.tips, oo.tolls, oo.upfront_price, oo.fare_matched_upfront, oo.settled_at,
+             (COALESCE(oo.total_earned,0) + COALESCE(oo.tips,0) + COALESCE(oo.tolls,0)) AS total_realized
       FROM offer_intelligence oi
       LEFT JOIN offer_outcomes oo ON oo.offer_intelligence_id = oi.id
       WHERE oi.user_id = ${req.auth.userId}
@@ -239,7 +241,11 @@ router.get('/offers', async (req, res) => {
       // Realized dollars count only rides actually taken — earnings that linger
       // on a Rejected/Cancelled outcome row must not inflate the total.
       realized_total: Math.round(offers.reduce((sum, o) =>
-        sum + (['Accepted', 'Completed'].includes(o.driver_decision) ? (Number(o.total_earned) || 0) : 0), 0) * 100) / 100,
+        sum + (['Accepted', 'Completed'].includes(o.driver_decision) ? (Number(o.total_realized) || 0) : 0), 0) * 100) / 100,
+      // Upfront-fare honesty test (2026-08-24): how many settled fares were
+      // validated against the accepted upfront price, and how many differed.
+      fares_validated: offers.filter((o) => o.fare_matched_upfront != null).length,
+      fare_mismatches: offers.filter((o) => o.fare_matched_upfront === false).length,
     };
 
     res.json({ success: true, stats, offers });
@@ -254,16 +260,25 @@ router.get('/offers', async (req, res) => {
 router.post('/offers/:id/outcome', async (req, res) => {
   try {
     const offerId = req.params.id;
-    const { driver_decision, driver_reasoning, actual_pay, reimbursements, extras, other } = req.body || {};
+    const {
+      driver_decision, driver_reasoning, actual_pay, reimbursements, extras, other,
+      tips, tolls, upfront_price, fare_matched_upfront, settled,
+    } = req.body || {};
 
     if (driver_decision != null && !OUTCOME_VALUES.includes(driver_decision)) {
       return res.status(400).json({ error: `driver_decision must be one of ${OUTCOME_VALUES.join(', ')} or null` });
     }
     const num = (v) => (v == null || v === '' ? null : Number(v));
-    for (const [k, v] of Object.entries({ actual_pay, reimbursements, extras, other })) {
+    for (const [k, v] of Object.entries({ actual_pay, reimbursements, extras, other, tips, tolls, upfront_price })) {
       if (num(v) != null && (!Number.isFinite(num(v)) || num(v) < 0 || num(v) > 10000)) {
         return res.status(400).json({ error: `${k} must be a number between 0 and 10000` });
       }
+    }
+    if (fare_matched_upfront != null && typeof fare_matched_upfront !== 'boolean') {
+      return res.status(400).json({ error: 'fare_matched_upfront must be a boolean or null' });
+    }
+    if (settled != null && typeof settled !== 'boolean') {
+      return res.status(400).json({ error: 'settled must be a boolean or null' });
     }
 
     // Ownership: the offer must be mine (user_id was stamped at ingest).
@@ -276,10 +291,13 @@ router.post('/offers/:id/outcome', async (req, res) => {
     const result = await db.execute(sql`
       INSERT INTO offer_outcomes
         (user_id, offer_intelligence_id, driver_decision, driver_reasoning,
-         actual_pay, reimbursements, extras, other, outcome_source)
+         actual_pay, reimbursements, extras, other,
+         tips, tolls, upfront_price, fare_matched_upfront, settled_at, outcome_source)
       VALUES
         (${req.auth.userId}, ${offerId}, ${driver_decision ?? null}, ${driver_reasoning ?? null},
-         ${num(actual_pay)}, ${num(reimbursements)}, ${num(extras)}, ${num(other)}, 'web_app')
+         ${num(actual_pay)}, ${num(reimbursements)}, ${num(extras)}, ${num(other)},
+         ${num(tips)}, ${num(tolls)}, ${num(upfront_price)}, ${fare_matched_upfront ?? null},
+         ${settled ? sql`NOW()` : null}, 'web_app')
       ON CONFLICT (offer_intelligence_id) WHERE offer_intelligence_id IS NOT NULL
       DO UPDATE SET
         driver_decision = EXCLUDED.driver_decision,
@@ -288,12 +306,18 @@ router.post('/offers/:id/outcome', async (req, res) => {
         reimbursements = EXCLUDED.reimbursements,
         extras = EXCLUDED.extras,
         other = EXCLUDED.other,
+        tips = EXCLUDED.tips,
+        tolls = EXCLUDED.tolls,
+        upfront_price = EXCLUDED.upfront_price,
+        fare_matched_upfront = EXCLUDED.fare_matched_upfront,
+        settled_at = EXCLUDED.settled_at,
         updated_at = NOW()
-      RETURNING id, driver_decision, total_earned
+      RETURNING id, driver_decision, total_earned, tips, tolls, fare_matched_upfront, settled_at
     `);
 
     const row = result.rows?.[0];
-    console.log(`[offer-analyzer] Outcome: offer=${offerId} → ${row?.driver_decision ?? '(cleared)'} $${row?.total_earned ?? 0}`);
+    const totalRealized = (Number(row?.total_earned) || 0) + (Number(row?.tips) || 0) + (Number(row?.tolls) || 0);
+    console.log(`[offer-analyzer] Outcome: offer=${offerId} → ${row?.driver_decision ?? '(cleared)'} $${totalRealized}${row?.settled_at ? ' (settled)' : ''}${row?.fare_matched_upfront === false ? ' FARE MISMATCH' : ''}`);
     res.json({ success: true, outcome: row });
   } catch (err) {
     console.error('[offer-analyzer/outcome POST]', err.message);

--- a/server/lib/ai/rideshare-coach-dal.js
+++ b/server/lib/ai/rideshare-coach-dal.js
@@ -1444,7 +1444,10 @@ export class RideshareCoachDAL {
         WITH mine AS (
           SELECT oi.decision, oi.per_mile, oi.day_part, oi.day_of_week, oi.product_type,
                  oi.pickup_address, oi.local_date,
-                 oo.driver_decision, oo.total_earned
+                 oo.driver_decision,
+                 -- Grand total: tips/tolls (2026-08-24 fare validation) sit outside
+                 -- the generated total_earned column by design.
+                 (COALESCE(oo.total_earned,0) + COALESCE(oo.tips,0) + COALESCE(oo.tolls,0)) AS total_earned
           FROM offer_intelligence oi
           LEFT JOIN offer_outcomes oo ON oo.offer_intelligence_id = oi.id
           WHERE oi.user_id = ${userId}

--- a/server/lib/offers/parse-offer-text.js
+++ b/server/lib/offers/parse-offer-text.js
@@ -247,6 +247,7 @@ export function parseOfferText(rawText) {
       per_mile: null, per_minute: null,
       surge: null, product_type: null, advantage_pct: null,
       platform_hint: null, parse_confidence: 'minimal',
+      is_exclusive: null,
     };
   }
 
@@ -323,6 +324,13 @@ export function parseOfferText(rawText) {
     advantage_pct: advantagePct,
     platform_hint: platformHint,
     parse_confidence: parseConfidence,
+    // 2026-08-25 (Melody): exclusivity as a first-class flag, independent of the
+    // product name — the "Exclusive" chip renders separately from the product on
+    // Comfort/Priority cards, where extractProductType drops it. Declining a
+    // non-exclusive (Trip Radar / "Match") offer does not affect acceptance
+    // rate, so the ARP fallback is gated on this in rules-engine.js. Text
+    // present but no "Exclusive" anywhere → definite false (the chip is text).
+    is_exclusive: /\bexclusive\b/i.test(rawText),
   };
 }
 

--- a/server/lib/offers/rules-engine.js
+++ b/server/lib/offers/rules-engine.js
@@ -409,7 +409,14 @@ export function evaluateDeterministic(tier, raw, ruleset = DEFAULT_RULESET, cont
   // v3: Acceptance Rate Protection — the ladder (and possibly the floors)
   // failed, but total pay-per-mile clears the ARP line and no un-rescuable
   // gate fired above (spec: ACCEPT (FALLBACK)).
-  if (arp != null && perMile >= arp) {
+  // 2026-08-25 (Melody): ARP exists only to protect acceptance rate, and only
+  // declining an EXCLUSIVE offer hurts AR — a Trip Radar offer ("Match" button,
+  // no Exclusive badge) costs nothing to decline, so rescuing one buys a
+  // below-floor ride for zero AR benefit. Positively-detected non-exclusive
+  // (is_exclusive === false) blocks the rescue and falls through to the
+  // deferred floor rejects below; unknown (null/absent — legacy rows, field
+  // not extracted) preserves the rescue.
+  if (arp != null && perMile >= arp && raw.is_exclusive !== false) {
     return { decision: 'ACCEPT', reasonKind: 'accept_fallback', fallback: true, perMile, perMinute, totalMin };
   }
 
@@ -490,7 +497,8 @@ function renderRuleLines(tierName, eff, ruleset, { tierRulesOnly = false } = {})
   }
 
   if (!tierRulesOnly && g.acceptance_rate_protection?.min_per_total_mile != null) {
-    rules.push(`ACCEPT with "fallback":true if $/mi>=${fmt(g.acceptance_rate_protection.min_per_total_mile)}.`);
+    // 2026-08-25 (Melody): fallback only where declining costs AR — Exclusive offers.
+    rules.push(`ACCEPT with "fallback":true if $/mi>=${fmt(g.acceptance_rate_protection.min_per_total_mile)} and "Exclusive" badge shown (Trip Radar / "Match" offers: never fallback).`);
   }
 
   rules.push('REJECT.');
@@ -553,7 +561,8 @@ function templateExtras(eff) {
   const g = eff.global || {};
   let extras = '';
   if (g.pickup_limits) extras += ',"pickup_miles":0,"pickup_minutes":0';
-  if (g.acceptance_rate_protection?.min_per_total_mile != null) extras += ',"fallback":false';
+  // is_exclusive rides with ARP: it is what gates the fallback (2026-08-25).
+  if (g.acceptance_rate_protection?.min_per_total_mile != null) extras += ',"fallback":false,"is_exclusive":false';
   if (g.notices && Object.values(g.notices).some(Boolean)) extras += ',"notices":[]';
   return extras;
 }
@@ -657,7 +666,7 @@ export function buildPhase1VisionPrompt(ruleset = DEFAULT_RULESET, context = {})
   const numberedGlobal = globalRules.map((r, i) => `${i + 1}. ${r}`).join('\n');
   const arp = eff.global?.acceptance_rate_protection?.min_per_total_mile;
   const arpLine = arp != null
-    ? `No tier rule matched but $/mi>=${fmt(arp)}: ACCEPT with "fallback":true.\n`
+    ? `No tier rule matched but $/mi>=${fmt(arp)} and "Exclusive" badge shown: ACCEPT with "fallback":true. Trip Radar ("Match" button, no Exclusive badge): never fallback.\n`
     : '';
 
   // Headers reflect ACTUAL routing under this ruleset: enabling comfort/xl pulls
@@ -714,7 +723,7 @@ ${tierSections}
 ${arpLine}No tier rule matched: REJECT.
 ${extraBlock}
 rating: the rider rating if shown, else 0.
-judgment_reject: if you REJECT for a non-numeric reason (avoid area, road safety, Verified missing, multiple stops, round trip, share), name it (e.g. "avoid:Denton", "safety", "verified_missing", "stops", "round_trip", "share"); otherwise "".
+${arp != null ? 'is_exclusive: true if the "Exclusive" badge is shown, false if not (a Trip Radar offer shows "Match" and no badge).\n' : ''}judgment_reject: if you REJECT for a non-numeric reason (avoid area, road safety, Verified missing, multiple stops, round trip, share), name it (e.g. "avoid:Denton", "safety", "verified_missing", "stops", "round_trip", "share"); otherwise "".
 reason: terse. "$1.14 8.3mi" or "$0.78 14.0mi low". No sentences.
 
 ${jsonTemplate}`;
@@ -746,7 +755,7 @@ export function buildPhase2Prompt(ruleset = DEFAULT_RULESET, context = {}) {
     .map((r, i) => `  ${i + 1}. ${r}`);
   const arpMile = eff.global?.acceptance_rate_protection?.min_per_total_mile;
   const arpGeneral = arpMile != null
-    ? `\n  - No tier rule matched but $/mi>=${fmt(arpMile)} and no other gate fired: ACCEPT (mark "fallback").`
+    ? `\n  - No tier rule matched but $/mi>=${fmt(arpMile)}, no other gate fired, and the offer is Exclusive (badge shown): ACCEPT (mark "fallback"). Trip Radar ("Match", no Exclusive badge): never fallback.`
     : '';
 
   const guidance = renderGuidanceLines(eff);

--- a/server/lib/venue/resolution-coalescer.js
+++ b/server/lib/venue/resolution-coalescer.js
@@ -1,0 +1,82 @@
+// server/lib/venue/resolution-coalescer.js
+// 2026-08-26 (Melody's #2: prevent repeated Google address lookups while
+// recommendations load): stampede control for venue address resolution.
+//
+// WHY: every GET poll of a READY Smart Blocks snapshot re-enters
+// mapCandidatesToBlocks → resolveVenueAddressesBatch → resolveVenueAddress
+// (blocks-fast.js). venue_catalog absorbs repeats only when the upsert
+// succeeded — a geocoding-fallback result with no venue name is never
+// upserted, and a failed upsert is non-blocking — so those venues re-called
+// Google Places/Geocoding on EVERY poll, and two concurrent polls both
+// called on any cache miss. Total-failure throws (fail-loud, by design)
+// cached nothing, so a stampede of polls re-hit both APIs each time.
+//
+// HOW: one entry per key holding the resolution PROMISE.
+//   • in flight  → every caller shares the same promise (one upstream call).
+//   • resolved   → served for positiveTtlMs (shields the never-upserted
+//                  geocode case between polls; venue_catalog covers beyond).
+//   • rejected   → the SAME rejection is served for negativeTtlMs — every
+//                  caller still fails loudly, but a poll stampede cannot
+//                  multiply upstream calls; after the window the next caller
+//                  retries fresh (an API blip recovers in ~a minute).
+//
+// Per-instance, like the request-dedup memos (Cloud Run autoscale note in
+// server/lib/offers/request-dedup.js — the storage-level venue_catalog cache
+// covers the cross-instance gap for successes). PURE (no db imports, injected
+// clock) — jest-safe; regression coverage in
+// tests/venue/resolution-coalescer.test.js.
+
+export const DEFAULT_POSITIVE_TTL_MS = 10 * 60_000;
+export const DEFAULT_NEGATIVE_TTL_MS = 60_000;
+const DEFAULT_MAX_ENTRIES = 500;
+
+/**
+ * @param {{positiveTtlMs?: number, negativeTtlMs?: number, maxEntries?: number, now?: () => number}} [opts]
+ */
+export function createResolutionCoalescer({
+  positiveTtlMs = DEFAULT_POSITIVE_TTL_MS,
+  negativeTtlMs = DEFAULT_NEGATIVE_TTL_MS,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  now = Date.now,
+} = {}) {
+  const entries = new Map(); // key → { promise, expiresAt }
+
+  function sweep() {
+    const t = now();
+    for (const [k, e] of entries) {
+      if (e.expiresAt <= t) entries.delete(k);
+    }
+  }
+
+  return {
+    /**
+     * Run `fn` for `key`, sharing in-flight and recent outcomes.
+     * The returned promise rejects exactly as `fn`'s does — failures stay loud.
+     * @param {string} key
+     * @param {() => Promise<any>} fn
+     * @returns {Promise<any>}
+     */
+    run(key, fn) {
+      sweep();
+      const existing = entries.get(key);
+      if (existing) return existing.promise;
+
+      if (entries.size >= maxEntries) entries.delete(entries.keys().next().value);
+
+      // In-flight expiry = positive TTL: resolution calls settle in seconds,
+      // so a pending entry can never realistically outlive its window.
+      const entry = { promise: null, expiresAt: now() + positiveTtlMs };
+      entry.promise = Promise.resolve().then(fn);
+      entries.set(key, entry);
+
+      entry.promise.then(
+        () => { entry.expiresAt = now() + positiveTtlMs; },
+        () => { entry.expiresAt = now() + negativeTtlMs; } // also marks the rejection handled
+      );
+
+      return entry.promise;
+    },
+    size() { sweep(); return entries.size; },
+    clear() { entries.clear(); },
+  };
+}

--- a/server/lib/venue/venue-address-resolver.js
+++ b/server/lib/venue/venue-address-resolver.js
@@ -22,9 +22,20 @@ import {
   normalizeVenueName,
   parseAddressComponents
 } from './venue-utils.js';
+import { createResolutionCoalescer } from './resolution-coalescer.js';
 
 const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
 const PLACES_TEXT_SEARCH_URL = 'https://places.googleapis.com/v1/places:searchText';
+
+// 2026-08-26 (Melody's #2): stampede control — concurrent/repeated resolutions
+// of the same (coords, name) share one piece of work, successes are held long
+// enough to bridge poll intervals (the geocoding-fallback path never upserts
+// into venue_catalog, so it had NO cache at all), and a total-failure throw is
+// replayed for a short window instead of re-hitting Google on every poll.
+// Side effect, deliberate: venue_catalog access_count now ticks once per
+// coalescer window per instance, not once per poll — it is an analytics
+// counter, not ground truth.
+const resolutionCoalescer = createResolutionCoalescer();
 
 /**
  * Resolve venue coordinates to a formatted address
@@ -39,11 +50,19 @@ const PLACES_TEXT_SEARCH_URL = 'https://places.googleapis.com/v1/places:searchTe
  * @param {number} lng - Longitude
  * @param {string} venueName - Venue name (used for Places search)
  * @param {Object} options - Optional configuration
- * @param {boolean} options.skipCache - Skip cache lookup (force fresh API call)
+ * @param {boolean} options.skipCache - Skip cache lookup (force fresh API call; also bypasses the coalescer)
  * @param {boolean} options.upsertCache - Whether to upsert result into venue_catalog (default: true)
  * @returns {Promise<Object|null>} - Venue object with address fields or null
  */
 export async function resolveVenueAddress(lat, lng, venueName = null, options = {}) {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  // skipCache means "force fresh work" — it must not read OR seed shared state.
+  if (options.skipCache) return resolveVenueAddressDirect(lat, lng, venueName, options);
+  const key = `${generateCoordKey(lat, lng)}|${normalizeVenueName(venueName) || ''}`;
+  return resolutionCoalescer.run(key, () => resolveVenueAddressDirect(lat, lng, venueName, options));
+}
+
+async function resolveVenueAddressDirect(lat, lng, venueName = null, options = {}) {
   const { skipCache = false, upsertCache = true } = options;
 
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
@@ -371,6 +390,10 @@ async function upsertVenueCatalog(venue) {
 
 /**
  * Batch resolve addresses for multiple venues (optimized for performance)
+ *
+ * 2026-08-26: duplicate (coords, name) pairs — inside one batch or across
+ * concurrent batches (two polls of the same ready snapshot) — share a single
+ * resolution via the coalescer in resolveVenueAddress; no dedup needed here.
  *
  * @param {Array} venues - Array of {lat, lng, name}
  * @returns {Promise<Object>} - Map of venue key → address result

--- a/shared/schema.js
+++ b/shared/schema.js
@@ -1977,6 +1977,16 @@ export const offer_outcomes = pgTable("offer_outcomes", {
     sql`COALESCE(actual_pay,0) + COALESCE(reimbursements,0) + COALESCE(extras,0) + COALESCE(other,0)`
   ),
 
+  // Upfront-fare validation (2026-08-24, migrations/20260824). tips/tolls sit
+  // OUTSIDE the generated total_earned (altering a generated column isn't
+  // additive) — readers compute the grand total as
+  // COALESCE(total_earned,0)+COALESCE(tips,0)+COALESCE(tolls,0).
+  tips: doublePrecision("tips"),
+  tolls: doublePrecision("tolls"),
+  upfront_price: doublePrecision("upfront_price"),     // offer_intelligence.price snapshot at validation (FK is SET NULL)
+  fare_matched_upfront: boolean("fare_matched_upfront"), // NULL until validated; TRUE matched; FALSE differed (actual in actual_pay)
+  settled_at: timestamp("settled_at", { withTimezone: true }), // NULL = still open in the Recent Offers queue
+
   outcome_source: text("outcome_source").notNull().default('web_app'),
 
   created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/tests/offers/rules-engine-v3.test.js
+++ b/tests/offers/rules-engine-v3.test.js
@@ -169,6 +169,18 @@ describe('v3 deterministic gates (spec rules)', () => {
     expect(r).toMatchObject({ decision: 'ACCEPT', reasonKind: 'accept_fallback', fallback: true });
   });
 
+  it('ARP never rescues a Trip Radar offer (is_exclusive false) — Melody 2026-08-25', () => {
+    // Declining a non-exclusive ("Match") offer does not affect acceptance rate,
+    // so the fallback would buy a below-rung ride for zero AR benefit.
+    const radar = { per_mile: 1.20, per_minute: 0.40, total_minutes: 18, is_exclusive: false };
+    expect(evaluateDeterministic('standard', radar, rs).decision).toBe('REJECT');
+    expect(evaluateDeterministic('standard', { ...radar, is_exclusive: true }, rs))
+      .toMatchObject({ decision: 'ACCEPT', reasonKind: 'accept_fallback', fallback: true });
+    // Unknown exclusivity (legacy rows / field not extracted) preserves the rescue.
+    expect(evaluateDeterministic('standard', { ...radar, is_exclusive: null }, rs))
+      .toMatchObject({ decision: 'ACCEPT', reasonKind: 'accept_fallback' });
+  });
+
   it('ARP does not rescue below its floor: $0.95/mi stays REJECT', () => {
     // floor_per_mile is 1.00 in the spec config → floor fires first.
     const r = evaluateDeterministic('standard', { per_mile: 0.95, per_minute: 0.60, total_minutes: 15 }, rs);
@@ -221,12 +233,13 @@ describe('prompt rendering with v3 rules enabled', () => {
     const p = buildPhase1Prompt('standard', rs);
     expect(p).toContain('REJECT if pickup_mi>3 or pickup_min>8.');
     expect(p).toContain('REJECT if total_min>20 unless $/mi>=2.00 and $/min>=1.00.');
-    expect(p).toContain('ACCEPT with "fallback":true if $/mi>=1.00.');
+    expect(p).toContain('ACCEPT with "fallback":true if $/mi>=1.00 and "Exclusive" badge shown (Trip Radar / "Match" offers: never fallback).');
     expect(p).toContain('REJECT if trip heads toward Fort Worth and ride_mi>=8.');
     expect(p).toContain('REJECT if destination is in or within ~6mi of Denton.');
     expect(p).toContain('REJECT if destination is north of US-380.');
     expect(p).toContain('"pickup_miles":0');
     expect(p).toContain('"fallback":false');
+    expect(p).toContain('"is_exclusive":false');
     expect(p).toContain('"notices":[]');
     expect(p).toContain('rating visible and <4.9');
   });
@@ -238,7 +251,7 @@ describe('prompt rendering with v3 rules enabled', () => {
     expect(p).toContain('XL');
     expect(p).toContain('"product":""');
     // ARP must render AFTER tier sections (first-match-wins ordering).
-    const arpIdx = p.indexOf('$/mi>=1.00: ACCEPT with "fallback":true');
+    const arpIdx = p.indexOf('$/mi>=1.00 and "Exclusive" badge shown: ACCEPT with "fallback":true');
     const xlIdx = p.indexOf('XL (');
     expect(arpIdx).toBeGreaterThan(xlIdx);
     expect(arpIdx).toBeGreaterThan(-1);

--- a/tests/venue/resolution-coalescer.test.js
+++ b/tests/venue/resolution-coalescer.test.js
@@ -1,0 +1,116 @@
+// tests/venue/resolution-coalescer.test.js
+// 2026-08-26 (Melody's #2: prevent repeated Google address lookups while
+// recommendations load). Regression contract: multiple polls of a ready Smart
+// Blocks snapshot must not multiply external API calls — concurrent
+// resolutions share in-flight work, successes bridge poll intervals, and
+// failures are replayed loudly for a short window instead of stampeding
+// Google. Pure module, injected clock — no db/fetch mocks needed.
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  createResolutionCoalescer,
+  DEFAULT_POSITIVE_TTL_MS,
+  DEFAULT_NEGATIVE_TTL_MS,
+} from '../../server/lib/venue/resolution-coalescer.js';
+
+function makeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms) => { t += ms; } };
+}
+
+describe('resolution coalescer', () => {
+  it('concurrent calls for the same key share ONE piece of work', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now });
+    const fn = jest.fn().mockResolvedValue({ formatted_address: '123 Main St' });
+
+    const [a, b, d] = await Promise.all([
+      c.run('32.9|-96.8|omni', fn),
+      c.run('32.9|-96.8|omni', fn),
+      c.run('32.9|-96.8|omni', fn),
+    ]);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(b).toBe(d);
+    expect(a.formatted_address).toBe('123 Main St');
+  });
+
+  it('sequential polls within the positive TTL reuse the result; after it, work re-runs', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now });
+    const fn = jest.fn().mockResolvedValue({ ok: true });
+
+    await c.run('k', fn);
+    clock.advance(DEFAULT_POSITIVE_TTL_MS - 1);
+    await c.run('k', fn);
+    expect(fn).toHaveBeenCalledTimes(1); // 15s poll loop, focus refetches — one upstream call
+
+    clock.advance(2); // past expiry
+    await c.run('k', fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('distinct keys never share', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now });
+    const fn = jest.fn().mockResolvedValue({});
+
+    await Promise.all([c.run('a', fn), c.run('b', fn)]);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('failure stays LOUD for every caller but is not recomputed within the negative TTL', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now });
+    const fn = jest.fn().mockRejectedValue(new Error('all resolution methods exhausted'));
+
+    // Both concurrent pollers get the rejection; upstream called once.
+    const settled = await Promise.allSettled([c.run('k', fn), c.run('k', fn)]);
+    expect(settled.map((s) => s.status)).toEqual(['rejected', 'rejected']);
+    expect(settled[0].reason.message).toMatch(/exhausted/);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Next poll inside the negative window: same loud failure, still one call.
+    clock.advance(DEFAULT_NEGATIVE_TTL_MS - 1);
+    await expect(c.run('k', fn)).rejects.toThrow(/exhausted/);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Window over: the blip may have cleared — retry fresh.
+    clock.advance(2);
+    fn.mockResolvedValueOnce({ recovered: true });
+    await expect(c.run('k', fn)).resolves.toEqual({ recovered: true });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failure expires faster than a success (negative TTL < positive TTL)', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now, positiveTtlMs: 1000, negativeTtlMs: 100 });
+    const fail = jest.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(c.run('k', fail)).rejects.toThrow('boom');
+    clock.advance(150); // past negative, well inside positive
+    fail.mockResolvedValueOnce({ ok: true });
+    await expect(c.run('k', fail)).resolves.toEqual({ ok: true });
+    expect(fail).toHaveBeenCalledTimes(2);
+  });
+
+  it('entry count is bounded (oldest evicted at maxEntries)', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now, maxEntries: 3 });
+    const fn = () => Promise.resolve({});
+
+    await Promise.all(['a', 'b', 'c', 'd', 'e'].map((k) => c.run(k, fn)));
+    expect(c.size()).toBeLessThanOrEqual(3);
+  });
+
+  it('expired entries are swept on access', async () => {
+    const clock = makeClock();
+    const c = createResolutionCoalescer({ now: clock.now, positiveTtlMs: 100 });
+    await c.run('a', () => Promise.resolve({}));
+    await c.run('b', () => Promise.resolve({}));
+    expect(c.size()).toBe(2);
+    clock.advance(200);
+    expect(c.size()).toBe(0);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Three driver-requested changes:

**1. Upfront-fare validation (commit `84fe123`)** — Reworks the OffersCard outcome capture into the Earnings Log settlement flow: recording an **Accepted/Completed** offer opens a panel with the fare **pre-filled at the accepted upfront price and locked**. The driver adds **Tips / Tolls / Extras** on top. A *"Paid different than what I accepted"* checkbox unlocks the fare field and records `fare_matched_upfront = false` with the real payout — a per-offer test of whether Uber honors its upfront fares. Saving stamps `settled_at` and the offer **leaves the Recent Offers queue**; Rejected/Cancelled settle immediately. A *Show settled* toggle reveals history with a "Fare matched" / "Paid $X vs $Y accepted" badge.

**2. ARP × Trip Radar gate (commit `9395b32`)** — The acceptance-rate-protection fallback exists only to protect AR, and only declining an **Exclusive** offer hurts AR — a Trip Radar offer ("Match" button, no Exclusive badge) costs nothing to decline, so rescuing one bought a below-floor ride for zero benefit. `is_exclusive` becomes a first-class flag independent of the product name (the chip renders separately on Comfort/Priority cards): text-lane regex, vision-lane model boolean (joins the JSON template whenever ARP is enabled). `evaluateDeterministic` rescues only when `is_exclusive !== false` — unknown (legacy) preserves the rescue; the condition is rendered into the tier, vision, and Phase-2 prompts.

**3. Venue address-resolution coalescing (commit `5e98d97`)** — Every GET poll of a READY Smart Blocks snapshot re-entered `mapCandidatesToBlocks` → `resolveVenueAddressesBatch` → per-venue resolution. `venue_catalog` absorbed repeats only when the upsert succeeded — the geocoding-fallback path (no venue name) never upserts, failed upserts are non-blocking, and total-failure throws cached nothing — so those venues re-called Places/Geocoding on every poll, and concurrent polls both called on any cache miss. A new pure `resolution-coalescer` (injected clock, per-instance like the request-dedup memos) shares in-flight work per (coords, name), holds successes 10 min, and replays failures loudly for 60 s instead of recomputing per poll. Client: the blocks query gains `staleTime`/`gcTime` mirroring the strategy query so focus/remount refetches stop re-hitting a ready response (SSE `blocks_ready` and manual refetch bypass staleTime).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)

## Changes Made

- `migrations/20260824_offer_outcomes_fare_validation.sql` — additive columns on `offer_outcomes`: `tips`, `tolls`, `upfront_price`, `fare_matched_upfront`, `settled_at`. No drops/alters; the generated `total_earned` untouched.
- `shared/schema.js` — Drizzle mirror of the five columns.
- `server/api/offer-analyzer/index.js` — GET `/offers` returns the new columns plus `total_realized` and stats `fares_validated` / `fare_mismatches`; POST `/offers/:id/outcome` accepts the new fields (`settled` → `settled_at`).
- `server/lib/ai/rideshare-coach-dal.js` — `getOfferPatterns` aggregates the grand total including tips/tolls.
- `client/src/components/offer-analyzer/OffersCard.tsx` — settlement panel, queue behavior, upfront-fare stat line.
- `server/lib/offers/parse-offer-text.js` — `is_exclusive` flag from raw text.
- `server/lib/offers/rules-engine.js` — ARP rescue gated on `is_exclusive !== false`; Exclusive condition in all three prompts; `"is_exclusive"` in the JSON template when ARP enabled.
- `server/api/hooks/analyze-offer.js` — vision-lane `is_exclusive` extraction + persisted in `parsed_data_json`.
- `server/lib/venue/resolution-coalescer.js` (new) — pure stampede-control module (in-flight sharing, positive/negative TTLs, bounded entries, injected clock).
- `server/lib/venue/venue-address-resolver.js` — `resolveVenueAddress` runs through the coalescer (`skipCache` bypasses it); batch resolution inherits the sharing.
- `client/src/contexts/co-pilot-context.tsx` — blocks query `staleTime: 5min` / `gcTime: 10min`.
- `tests/offers/rules-engine-v3.test.js` — pinned prompt strings updated; radar-gate test added.
- `tests/venue/resolution-coalescer.test.js` (new) — concurrent sharing, TTL expiry, loud-but-bounded failures, negative < positive TTL, entry bound, sweep.
- `docs/architecture/OFFER_ANALYZER.md` — fare validation sections + decision-order table and ARP×exclusivity note.

## Testing

- [ ] Ran seed script: `node scripts/seed-dev.js`
- [ ] Jest tests pass: `npm run test:blocks`
- [ ] Playwright tests pass: `npx playwright test`
- [ ] Full test suite: `./scripts/test-all.sh`
- [ ] Manual testing in browser
- [ ] Tested on mobile/responsive

`node --check` passes on all touched server files. The remote container cannot install dependencies (lockfile resolves through `package-firewall.replit.local`), so run in dev before merging: `npx jest tests/offers/rules-engine-v3.test.js tests/venue/resolution-coalescer.test.js`.

## Block Schema Contract

- [x] No changes to block schema

## Database Changes

- [ ] No database changes
- [x] Added new columns/tables (applied at boot by `server/db/run-migrations.js`)
- [x] Updated Drizzle schema in `shared/schema.js`
- [ ] Tested migration locally
- [ ] Updated seed script if needed

All five `ADD COLUMN IF NOT EXISTS` statements are additive and idempotent.

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed my own code
- [x] Commented complex/non-obvious code
- [x] Updated relevant documentation
- [x] Tests added/updated for changes
- [ ] All tests pass locally
- [ ] No console errors or warnings
- [ ] Checked LSP diagnostics (no TypeScript errors)

## Screenshots

UI changes are the OffersCard settlement panel — worth a manual look in dev before marking ready.

## Related Issues

Related to the Offer Analyzer outcome-capture design (2026-07-03, todo #10) and quota item #2 (repeated Google address lookups while recommendations load).

## Notes for Reviewers

- Settlement is an explicit `settled_at`, not derived from earnings.
- `tips`/`tolls` sit outside the generated `total_earned` column; readers compute `COALESCE(total_earned,0)+COALESCE(tips,0)+COALESCE(tolls,0)`.
- ARP gate default: **unknown exclusivity preserves the rescue** — only a positively-detected radar is blocked.
- Coalescer side effect, deliberate: `venue_catalog.access_count` now ticks once per coalescer window per instance, not once per poll — it is an analytics counter, not ground truth.
- Failures still throw to every caller (fail-loud preserved); they are simply not **recomputed** more than once per minute per venue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA5XDeyzS2jxr8MuV59sdv